### PR TITLE
Blackbox semiauto typeclass derivation

### DIFF
--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import cats.{Contravariant, FlatMap, Functor, Invariant}
+
+object Derive {
+  def functor[F[_]]: Functor[F] = macro DeriveMacros.functor[F]
+  def contravariant[F[_]]: Contravariant[F] = macro DeriveMacros.contravariant[F]
+  def invariant[F[_]]: Invariant[F] = macro DeriveMacros.invariant[F]
+  def flatMap[F[_]]: FlatMap[F] = macro DeriveMacros.flatMap[F]
+  def functorK[Alg[_[_]]]: FunctorK[Alg] = macro DeriveMacros.functorK[Alg]
+  def invariantK[Alg[_[_]]]: InvariantK[Alg] = macro DeriveMacros.invariantK[Alg]
+  def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = macro DeriveMacros.semigroupalK[Alg]
+  def applyK[Alg[_[_]]]: ApplyK[Alg] = macro DeriveMacros.applyK[Alg]
+}

--- a/macros/src/main/scala/cats/tagless/DeriveMacros.scala
+++ b/macros/src/main/scala/cats/tagless/DeriveMacros.scala
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import cats.data.Tuple2K
+import cats.{Contravariant, FlatMap, Functor, Invariant}
+
+import scala.reflect.macros.blackbox
+
+class DeriveMacros(val c: blackbox.Context) {
+  import c.internal._
+  import c.universe._
+
+  case class Method(m: MethodSymbol, tps: List[TypeDef], pss: List[List[ValDef]], rt: Type, body: Tree) {
+    def typeArgs: List[Type] = for (tp <- tps) yield typeRef(NoPrefix, tp.symbol, Nil)
+    def paramLists(f: Type => Type): List[List[ValDef]] = for (ps <- pss)
+      yield for (p <- ps) yield ValDef(p.mods, p.name, TypeTree(f(p.tpt.tpe)), p.rhs)
+    def argLists(f: TermSymbol => Tree): List[List[Tree]] = for (ps <- pss)
+      yield for (p <- ps) yield f(p.symbol.asTerm)
+    def definition: Tree = q"override def ${m.name}[..$tps](...$pss): $rt = $body"
+  }
+
+  /** Return the set of members of `tpe`, excluding some undesired cases. */
+  def membersOf(tpe: Type): Iterable[Symbol] = {
+    import definitions._
+    val exclude = Set[Symbol](AnyClass, AnyRefClass, AnyValClass, ObjectClass)
+    tpe.members.filterNot(m => m.isConstructor || exclude(m.owner))
+  }
+
+  /** Delegate the definition of type members and aliases in `algebra`. */
+  def delegateTypes(algebra: Type, members: Iterable[Symbol])(rhs: (TypeSymbol, List[Type]) => Type): Iterable[Tree] =
+    for (member <- members if member.isType) yield {
+      val tpe = member.asType
+      val signature = tpe.typeSignatureIn(algebra)
+      val typeParams = for (t <- signature.typeParams) yield typeDef(t)
+      val typeArgs = for (t <- signature.typeParams) yield typeRef(NoPrefix, t, Nil)
+      q"type ${tpe.name}[..$typeParams] = ${rhs(tpe, typeArgs)}"
+    }
+
+  /** Delegate the definition of abstract type members and aliases in `algebra` to an existing `instance`. */
+  def delegateAbstractTypes(algebra: Type, members: Iterable[Symbol], instance: Type): Iterable[Tree] =
+    delegateTypes(algebra, members.filter(_.isAbstract))((tpe, typeArgs) => typeRef(instance, tpe, typeArgs))
+
+  /** Delegate the definition of methods in `algebra` to an existing `instance`. */
+  def delegateMethods(algebra: Type, members: Iterable[Symbol], instance: Symbol)(
+    transform: PartialFunction[Method, Method]
+  ): Iterable[Tree] = for (member <- members if member.isMethod && !member.asMethod.isAccessor) yield {
+    val method = member.asMethod
+    val signature = method.typeSignatureIn(algebra)
+    val typeParams = for (tp <- signature.typeParams) yield typeDef(tp)
+    val typeArgs = for (tp <- signature.typeParams) yield typeRef(NoPrefix, tp, Nil)
+    val paramLists = for (ps <- signature.paramLists) yield for (p <- ps) yield valDef(p)
+    val argLists = for (ps <- signature.paramLists) yield for (p <- ps) yield p.name.toTermName
+    val delegate = q"$instance.$method[..$typeArgs](...$argLists)"
+    val reified = Method(method, typeParams, paramLists, signature.finalResultType, delegate)
+    transform.applyOrElse(reified, identity[Method]).definition
+  }
+
+  /** Type-check a definition of type `instance` with stubbed methods to gain more type information. */
+  def declare(instance: Type): Tree = {
+    val stubs = delegateMethods(instance, membersOf(instance).filter(_.isAbstract), NoSymbol) {
+      case method => method.copy(body = q"_root_.scala.Predef.???")
+    }
+
+    val Block(List(declaration), _) = c.typecheck(q"new $instance { ..$stubs }")
+    declaration
+  }
+
+  /** Implement a possibly refined `algebra` with the provided `members`. */
+  def implement(algebra: Type, members: Iterable[Tree]): Tree = {
+    // If `members.isEmpty` we need an extra statement to ensure the generation of an anonymous class.
+    val nonEmptyMembers = if (members.isEmpty) q"()" :: Nil else members
+
+    algebra match {
+      case RefinedType(parents, scope) =>
+        val refinements = delegateTypes(algebra, scope.filterNot(_.isAbstract)) {
+          (tpe, _) => tpe.typeSignatureIn(algebra).resultType
+        }
+
+        q"new ..$parents { ..$refinements; ..$nonEmptyMembers }"
+      case _ =>
+        q"new $algebra { ..$nonEmptyMembers }"
+    }
+  }
+
+  /** Create a new instance of `typeClass` for `algebra`.
+    * `rhs` should define a mapping for each method (by name) to an implementation function based on type signature.
+    */
+  def instantiate(typeClass: TypeSymbol, algebra: Type)(rhs: (String, Type => Tree)*): Tree = {
+    val impl = rhs.toMap
+    val TcA = appliedType(typeClass, algebra)
+    val declaration @ ClassDef(_, _, _, Template(parents, self, members)) = c.typecheck(declare(TcA))
+    val implementations = for (member <- members) yield member match {
+      case dd: DefDef =>
+        val method = member.symbol.asMethod
+        impl.get(method.name.toString).fold(dd)(f => defDef(method, f(method.typeSignatureIn(TcA))))
+      case other => other
+    }
+
+    val definition = classDef(declaration.symbol, Template(parents, self, implementations))
+    q"{ $definition; new ${declaration.symbol} }"
+  }
+
+  def mapK(algebra: Type): (String, Type => Tree) =
+    "mapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
+      val Af = singleType(NoPrefix, af)
+      val members = membersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = delegateMethods(Af, members, af.asTerm) {
+        case method @ Method(_, _, _, rt, delegate) if rt.typeSymbol == f =>
+          method.copy(rt = appliedType(g, rt.typeArgs), body = q"$fk($delegate)")
+      }
+
+      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+    }
+
+  def contramapK(algebra: Type): (String, Type => Tree) =
+    "contramapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
+      val Af = singleType(NoPrefix, af)
+      val members = membersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = delegateMethods(Af, members, af.asTerm) {
+        case method @ Method(m, _, pss, _, _) if pss.iterator.flatten.exists(_.tpt.symbol == f) =>
+          val paramLists = method.paramLists(tpe => if (tpe.typeSymbol == f) appliedType(g, tpe.typeArgs) else tpe)
+          val argLists = method.argLists(p => if (p.typeSignatureIn(Af).typeSymbol == f) q"$fk(${p.name})" else Ident(p.name))
+          val delegate = q"$af.$m[..${method.typeArgs}](...$argLists)"
+          method.copy(pss = paramLists, body = delegate)
+      }
+
+      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+    }
+
+  def imapK(algebra: Type): (String, Type => Tree) =
+    "imapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), MethodType(List(gk), _)))) =>
+      val Af = singleType(NoPrefix, af)
+      val members = membersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = delegateMethods(Af, members, af.asTerm) {
+        case method @ Method(m, _, pss, rt, _) if rt.typeSymbol == f || pss.iterator.flatten.exists(_.tpt.symbol == f) =>
+          val paramLists = method.paramLists(tpe => if (tpe.typeSymbol == f) appliedType(g, tpe.typeArgs) else tpe)
+          val argLists = method.argLists(p => if (p.typeSignatureIn(Af).typeSymbol == f) q"$gk(${p.name})" else Ident(p.name))
+          val returnType = if (rt.typeSymbol == f) appliedType(g, rt.typeArgs) else rt
+          val delegate = q"$af.$m[..${method.typeArgs}](...$argLists)"
+          val body = if (rt.typeSymbol == f) q"$fk($delegate)" else delegate
+          method.copy(pss = paramLists, rt = returnType, body = body)
+      }
+
+      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+    }
+
+  def productK(algebra: Type): (String, Type => Tree) = {
+    val Tuple2K = symbolOf[Tuple2K[Any, Any, Any]]
+    "productK" -> { case PolyType(List(f, g), MethodType(List(af, ag), _)) =>
+      val F = f.asType.toTypeConstructor
+      val G = g.asType.toTypeConstructor
+      val Af = singleType(NoPrefix, af)
+      val members = membersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = delegateMethods(Af, members, af.asTerm) {
+        case method @ Method(m, _, _, rt, delegate) if rt.typeSymbol == f =>
+          val argLists = method.argLists(p => Ident(p.name))
+          val FGA = F :: G :: rt.typeArgs
+          val returnType = appliedType(Tuple2K, FGA)
+          val body = q"new $Tuple2K[..$FGA]($delegate, $ag.$m[..${method.typeArgs}](...$argLists))"
+          method.copy(rt = returnType, body = body)
+      }
+
+      val typeParams = Tuple2K.typeParams.drop(2)
+      val typeArgs = F :: G :: typeParams.map(_.asType.toType)
+      val T2kAlg = appliedType(algebra, polyType(typeParams, appliedType(Tuple2K, typeArgs)))
+      implement(T2kAlg, types ++ methods)
+    }
+  }
+
+  def flatMapK(algebra: Type): (String, Type => Tree) =
+    "flatMapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
+      val Af = singleType(NoPrefix, af)
+      val members = membersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = delegateMethods(Af, members, af.asTerm) {
+        case method @ Method(m, _, _, rt, delegate) if rt.typeSymbol == f =>
+          val argLists = method.argLists(p => Ident(p.name))
+          val body = q"$fk($delegate).$m[..${method.typeArgs}](...$argLists)"
+          method.copy(rt = appliedType(g, rt.typeArgs), body = body)
+      }
+
+      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+    }
+
+  def tailRecM(algebra: Type): (String, Type => Tree) =
+    "tailRecM" -> { case PolyType(List(a, b), MethodType(List(x), MethodType(List(f), _))) =>
+      val Fa = appliedType(algebra, a.asType.toType)
+      val methods = delegateMethods(Fa, membersOf(Fa), NoSymbol) {
+        case method @ Method(m, _, _, rt, _) =>
+          val argLists = method.argLists(p => Ident(p.name))
+          if (rt.typeSymbol == a) {
+            val step = TermName(c.freshName("step"))
+            val current = TermName(c.freshName("current"))
+            val body = q"""{
+              @_root_.scala.annotation.tailrec def $step($current: $a): $b =
+                $f($current).$m[..${method.typeArgs}](...$argLists) match {
+                  case _root_.scala.Left(next) => $step(next)
+                  case _root_.scala.Right(target) => target
+                }
+
+              $step($x)
+            }"""
+
+            method.copy(rt = appliedType(b, rt.typeArgs), body = body)
+          } else {
+            val body = q"$f($x).$m[..${method.typeArgs}](...$argLists)"
+            method.copy(body = body)
+          }
+      }
+
+      implement(appliedType(algebra, b.asType.toTypeConstructor), methods)
+    }
+
+  def functor[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
+    val F = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[Functor[Any]], F)(mapK(F).copy(_1 = "map"))
+  }
+
+  def contravariant[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
+    val F = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[Contravariant[Any]], F)(contramapK(F).copy(_1 = "contramap"))
+  }
+
+  def invariant[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
+    val F = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[Invariant[Any]], F)(imapK(F).copy(_1 = "imap"))
+  }
+
+  def flatMap[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
+    val F = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[FlatMap[Any]], F)(mapK(F).copy(_1 = "map"), flatMapK(F).copy(_1 = "flatMap"), tailRecM(F))
+  }
+
+  def functorK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
+    val Alg = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[FunctorK[Any]], Alg)(mapK(Alg))
+  }
+
+  def invariantK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
+    val Alg = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[InvariantK[Any]], Alg)(imapK(Alg))
+  }
+
+  def semigroupalK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
+    val Alg = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[SemigroupalK[Any]], Alg)(productK(Alg))
+  }
+
+  def applyK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
+    val Alg = tag.tpe.typeConstructor.dealias
+    instantiate(symbolOf[ApplyK[Any]], Alg)(mapK(Alg), productK(Alg))
+  }
+}

--- a/macros/src/main/scala/cats/tagless/autoApplyK.scala
+++ b/macros/src/main/scala/cats/tagless/autoApplyK.scala
@@ -46,10 +46,7 @@ class ApplyKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) extends
       companionMapKDef,
       q"""
         implicit def ${Term.Name("applyKFor" + name.value)}[..$extraTParams]: _root_.cats.tagless.ApplyK[$typeLambdaVaryingHigherKindedEffect] =
-          new _root_.cats.tagless.ApplyK[$typeLambdaVaryingHigherKindedEffect] {
-            $instanceMapKDef
-            ${autoSemigroupalK.semigroupalKMethods(cls)}
-          }
+          _root_.cats.tagless.Derive.applyK[$typeLambdaVaryingHigherKindedEffect]
       """
     )
   }

--- a/macros/src/main/scala/cats/tagless/autoContravariant.scala
+++ b/macros/src/main/scala/cats/tagless/autoContravariant.scala
@@ -67,12 +67,8 @@ object autoContravariant {
 
     val instanceDef = Seq(q"""
       implicit def ${Term.Name("contravariantFor" + name.value)}[..$extraTParams]: _root_.cats.Contravariant[$typeLambdaVaryingEffect] =
-        new _root_.cats.Contravariant[$typeLambdaVaryingEffect] {
-          def contramap[T, TTarget](delegatee_ : $name[..${tArgs("T")}])(mapFunctionFrom: TTarget => T): $name[..${tArgs("TTarget")}] =
-            new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-              ..$methods
-            }
-        }""")
+        _root_.cats.tagless.Derive.contravariant[$typeLambdaVaryingEffect]
+    """)
 
     cls.copy(companion = cls.companion.addStats(instanceDef))
 

--- a/macros/src/main/scala/cats/tagless/autoFlatMap.scala
+++ b/macros/src/main/scala/cats/tagless/autoFlatMap.scala
@@ -94,22 +94,8 @@ object autoFlatMap {
 
     val instanceDef = Seq(q"""
       implicit def ${Term.Name("monadFor" + name.value)}[..$extraTParams]: _root_.cats.FlatMap[$typeLambdaVaryingEffect] =
-        new _root_.cats.FlatMap[$typeLambdaVaryingEffect] {
-          override def map[T, TTarget](delegatee_ : $name[..${tArgs("T")}])(mapFunction: T => TTarget): $name[..${tArgs("TTarget")}] =
-            new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-              ..${mapMethods(templ, effectTypeName)}
-            }
-
-          override def flatMap[T, TTarget](delegatee_ : $name[..${tArgs("T")}])(flatMapFunction: T => $name[..${tArgs("TTarget")}]): $name[..${tArgs("TTarget")}] =
-            new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-              ..$flatMapMethods
-            }
-
-          override def tailRecM[TInit, TTarget](init: TInit)(fn: TInit => $name[..${tArgs(t"Either[TInit, TTarget]")}]): $name[..${tArgs("TTarget")}] =
-            new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-              ..$tailRecMMethods
-            }
-        }""")
+        _root_.cats.tagless.Derive.flatMap[$typeLambdaVaryingEffect]
+    """)
 
     cls.copy(companion = cls.companion.addStats(instanceDef))
 

--- a/macros/src/main/scala/cats/tagless/autoFunctor.scala
+++ b/macros/src/main/scala/cats/tagless/autoFunctor.scala
@@ -38,15 +38,10 @@ object autoFunctor {
     import ad._
     import cls._
 
-    val instanceDef =
-      q"""
-    implicit def ${Term.Name("functorFor" + name.value)}[..$extraTParams]: _root_.cats.Functor[$typeLambdaVaryingEffect] =
-      new _root_.cats.Functor[$typeLambdaVaryingEffect] {
-        def map[T, TTarget](delegatee_ : $name[..${tArgs("T")}])(mapFunction: T => TTarget): $name[..${tArgs("TTarget")}] =
-          new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-            ..${autoFlatMap.mapMethods(templ, effectTypeName)}
-          }
-      }"""
+    val instanceDef = q"""
+      implicit def ${Term.Name("functorFor" + name.value)}[..$extraTParams]: _root_.cats.Functor[$typeLambdaVaryingEffect] =
+        _root_.cats.tagless.Derive.functor[$typeLambdaVaryingEffect]
+    """
 
     cls.copy(companion = cls.companion.addStats(Seq(instanceDef)))
   }

--- a/macros/src/main/scala/cats/tagless/autoFunctorK.scala
+++ b/macros/src/main/scala/cats/tagless/autoFunctorK.scala
@@ -64,9 +64,7 @@ class CovariantKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) ext
       companionMapKDef,
       q"""
         implicit def ${Term.Name("functorKFor" + name.value)}[..$extraTParams]: _root_.cats.tagless.FunctorK[$typeLambdaVaryingHigherKindedEffect] =
-          new _root_.cats.tagless.FunctorK[$typeLambdaVaryingHigherKindedEffect] {
-            $instanceMapKDef
-          }
+          _root_.cats.tagless.Derive.functorK[$typeLambdaVaryingHigherKindedEffect]
       """
     )
   }
@@ -76,10 +74,7 @@ class CovariantKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) ext
       q"""
        object fullyRefined {
          implicit def ${Term.Name("functorKForFullyRefined" + name.value)}[..${fullyRefinedTParams}]: _root_.cats.tagless.FunctorK[$typeLambdaVaryingHigherKindedEffectFullyRefined] =
-           new _root_.cats.tagless.FunctorK[$typeLambdaVaryingHigherKindedEffectFullyRefined] {
-             def mapK[F[_], G[_]]($from: ${fullyRefinedTypeSig("F")})(fk: _root_.cats.~>[F, G]):${fullyRefinedTypeSig("G")} =
-                ${newInstance(newTypeMemberFullyRefined)}
-         }
+            _root_.cats.tagless.Derive.functorK[$typeLambdaVaryingHigherKindedEffectFullyRefined]
 
          object autoDerive {
            @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))

--- a/macros/src/main/scala/cats/tagless/autoInvariant.scala
+++ b/macros/src/main/scala/cats/tagless/autoInvariant.scala
@@ -73,12 +73,8 @@ object autoInvariant {
 
     val instanceDef = Seq(q"""
       implicit def ${Term.Name("invariantFor" + name.value)}[..$extraTParams]: _root_.cats.Invariant[$typeLambdaVaryingEffect] =
-        new _root_.cats.Invariant[$typeLambdaVaryingEffect] {
-          def imap[T, TTarget](delegatee_ : $name[..${tArgs("T")}])(mapFunction: T => TTarget)(mapFunctionFrom: TTarget => T): $name[..${tArgs("TTarget")}] =
-            new ${Ctor.Ref.Name(name.value)}[..${tArgs("TTarget")}] {
-              ..$methods
-            }
-        }""")
+        _root_.cats.tagless.Derive.invariant[$typeLambdaVaryingEffect]
+    """)
 
     cls.copy(companion = cls.companion.addStats(instanceDef))
 

--- a/macros/src/main/scala/cats/tagless/autoInvariantK.scala
+++ b/macros/src/main/scala/cats/tagless/autoInvariantK.scala
@@ -137,18 +137,12 @@ class InvariantKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) ext
       """,
       q"""
         implicit def ${Term.Name("invariantKFor" + name.value)}[..$extraTParams]: _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffect] =
-          new _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffect] {
-            def imapK[F[_], G[_]]($from: $name[..${tArgs("F")}])(fk: _root_.cats.~>[F, G])(gk: _root_.cats.~>[G, F]): $name[..${tArgs("G")}] =
-            ${newInstance(newTypeMember(from))}
-          }
+          _root_.cats.tagless.Derive.invariantK[$typeLambdaVaryingHigherKindedEffect]
        """,
       q"""
        object fullyRefined {
          implicit def ${Term.Name("invariantKForFullyRefined" + name.value)}[..$fullyRefinedTParams]: _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffectFullyRefined] =
-            new _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffectFullyRefined] {
-              def imapK[F[_], G[_]]($from: ${fullyRefinedTypeSig("F")})(fk: _root_.cats.~>[F, G])(gk: _root_.cats.~>[G, F]): ${fullyRefinedTypeSig("G")} =
-                ${newInstance(newTypeMemberFullyRefined)}
-            }
+           _root_.cats.tagless.Derive.invariantK[$typeLambdaVaryingHigherKindedEffectFullyRefined]
          object autoDerive {
            @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
            implicit def fromInvariantK[${effectType}, G[_], ..${fullyRefinedTParams}](

--- a/macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
+++ b/macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
@@ -39,9 +39,7 @@ object autoSemigroupalK {
 
     val instanceDef = Seq(q"""
       implicit def ${Term.Name("semigroupalKFor" + name.value)}: _root_.cats.tagless.SemigroupalK[$name] =
-        new _root_.cats.tagless.SemigroupalK[$name] {
-          ${semigroupalKMethods(cls)}
-        }""")
+        _root_.cats.tagless.Derive.semigroupalK[$name]""")
 
     cls.copy(companion = cls.companion.addStats(instanceDef))
   }

--- a/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
@@ -84,7 +84,7 @@ object autoContravariantTest {
 
   @autoContravariant
   trait AlgWithGenericType[T] {
-    def foo[A](i: T, a: A): Int
+    def foo[U](i: T, a: U): Int
   }
 
   @autoContravariant

--- a/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
@@ -63,7 +63,7 @@ object autoFlatMapTests {
 
   @autoFlatMap
   trait AlgWithGenericMethod[T] {
-    def plusOne[A](i: A): T
+    def plusOne[U](i: U): T
   }
 
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =

--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
@@ -69,7 +69,7 @@ object autoFunctorTests {
 
   @autoFunctor
   trait AlgWithGenericMethod[T] {
-    def plusOne[A](i: A): T
+    def plusOne[U](i: U): T
   }
 
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
@@ -92,7 +92,7 @@ object autoInvariantTests {
 
   @autoInvariant
   trait AlgWithGenericType[T] {
-    def foo[A](i: T, a: A): T
+    def foo[U](i: T, a: U): T
   }
 
   @autoInvariant


### PR DESCRIPTION
As a first step towards migrating cats-tagless to `scala.reflect`
macros, we implement blackbox typeclass derivations macros.

There are many advantages to blackbox macros:
  * strictly less powerful technique than macro annotations
  * entirely type-driven hence cover more corner cases
  * enable semiauto style typeclass derivation for free
  * more friendly to IDEs and other tools (types are known)
  * likely to have more straightforward migration path in Scala 3

The `scala.meta` macro annotations are modified to call the
blackbox macros which means they generate one-liners.

The next step would be to complete replace `scala.meta` with
`scala.reflect` macro annotations.

Ref #6 
Closes #8