### PR TITLE
Blackbox macros: refresh type parameter names

### DIFF
--- a/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
@@ -84,7 +84,7 @@ object autoContravariantTest {
 
   @autoContravariant
   trait AlgWithGenericType[T] {
-    def foo[U](i: T, a: U): Int
+    def foo[A](i: T, a: A): Int
   }
 
   @autoContravariant

--- a/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
@@ -63,7 +63,7 @@ object autoFlatMapTests {
 
   @autoFlatMap
   trait AlgWithGenericMethod[T] {
-    def plusOne[U](i: U): T
+    def plusOne[A](i: A): T
   }
 
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =

--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
@@ -69,7 +69,7 @@ object autoFunctorTests {
 
   @autoFunctor
   trait AlgWithGenericMethod[T] {
-    def plusOne[U](i: U): T
+    def plusOne[A](i: A): T
   }
 
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
@@ -92,7 +92,7 @@ object autoInvariantTests {
 
   @autoInvariant
   trait AlgWithGenericType[T] {
-    def foo[U](i: T, a: U): T
+    def foo[A](i: T, a: A): T
   }
 
   @autoInvariant


### PR DESCRIPTION
This is a solution to the issue of type parameter shadowing.
Scalac issues a warning when we define a type parameter `A` if
there is already another one in scope with the same name.
This could be a problem for users with `-Xfatal-warnings` enabled.

The solution is to temporarily set fresh names for all type parameters,
type-check the tree and restore the original names afterwards.
It's a bit hacky, but self-contained.

Reverts type parameters which were renamed to work around the issue.

Follow up #22 
cc @ChristopherDavenport