### PR TITLE
added scala 2.13 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       scala: *scala_version_212
 
     - env: TEST="Macro tests scala 2.13"
-      script: sbt ++$TRAVIS_SCALA_VERSION! macroJVM/test
+      script: sbt ++$TRAVIS_SCALA_VERSION! macrosJVM/test
       scala: *scala_version_213
 
     # temporarily disabled due to random error resulted from conflict between scalameta macro and scala.reflect macro.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jdk:
 
 scala_version_211: &scala_version_211 2.11.12
 scala_version_212: &scala_version_212 2.12.7
+scala_version_213: &scala_version_213 2.13.0-M5
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle
@@ -43,6 +44,10 @@ jobs:
       scala: *scala_version_211
     - <<: *jvm_tests
       scala: *scala_version_212
+
+    - env: TEST="Macro tests scala 2.13"
+      script: sbt ++$TRAVIS_SCALA_VERSION! macroJVM/test
+      scala: *scala_version_213
 
     # temporarily disabled due to random error resulted from conflict between scalameta macro and scala.reflect macro.
     #- env: TEST="docs"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVe
 
 addCommandAlias("validateJVM", ";testsJVM/test ; docs/makeMicrosite")
 
-lazy val libs = org.typelevel.libraries
+lazy val libs = org.typelevel.libraries.add("kind-projector", "0.9.9")
 
 val apache2 = "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")
 val gh = GitHubSettings(org = "typelevel", proj = "cats-tagless", publishOrg = "org.typelevel", license = apache2)
@@ -137,7 +137,6 @@ lazy val docs = project
     scalacOptions in Tut ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
     git.remoteRepo := gh.repo,
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md")
-
 
 
 lazy val buildSettings = sharedBuildSettings(gh, libs)

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,9 @@ lazy val lawsM   = module("laws", CrossType.Pure)
   .enablePlugins(AutomateHeaderPlugin)
 
 
-lazy val legacyMacros    = prj(legacyMacrosM)
+lazy val legacyMacros    = prj(legacyMacrosM).settings(
+  crossScalaVersions := crossScalaVersions.value.filterNot(_ == libs.vers("scalac_2.13"))
+)
 lazy val legacyMacrosJVM = legacyMacrosM.jvm
 lazy val legacyMacrosJS  = legacyMacrosM.js
 lazy val legacyMacrosM   = module("legacy-macros", CrossType.Pure)
@@ -143,7 +145,7 @@ lazy val buildSettings = sharedBuildSettings(gh, libs)
 lazy val commonSettings = sharedCommonSettings ++ Seq(
   parallelExecution in Test := false,
   scalaVersion := libs.vers("scalac_2.12"),
-  crossScalaVersions := Seq(libs.vers("scalac_2.11"), scalaVersion.value),
+  crossScalaVersions := Seq(libs.vers("scalac_2.11"), scalaVersion.value, libs.vers("scalac_2.13")),
   developers := List(Developer("Kailuo Wang", "@kailuowang", "kailuo.wang@gmail.com", new java.net.URL("http://kailuowang.com")))
 ) ++ scalacAllSettings ++ unidocCommonSettings ++
   addCompilerPlugins(libs, "kind-projector") ++ copyrightHeader

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVe
 
 addCommandAlias("validateJVM", ";testsJVM/test ; docs/makeMicrosite")
 
-lazy val libs = org.typelevel.libraries.add("kind-projector", "0.9.9")
+lazy val libs = org.typelevel.libraries
 
 val apache2 = "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")
 val gh = GitHubSettings(org = "typelevel", proj = "cats-tagless", publishOrg = "org.typelevel", license = apache2)

--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,7 @@ lazy val buildSettings = sharedBuildSettings(gh, libs)
 lazy val commonSettings = sharedCommonSettings ++ Seq(
   parallelExecution in Test := false,
   scalaVersion := libs.vers("scalac_2.12"),
-  crossScalaVersions := Seq(libs.vers("scalac_2.11"), scalaVersion.value, libs.vers("scalac_2.13")),
+  crossScalaVersions := Seq(libs.vers("scalac_2.11"), scalaVersion.value),
   developers := List(Developer("Kailuo Wang", "@kailuowang", "kailuo.wang@gmail.com", new java.net.URL("http://kailuowang.com")))
 ) ++ scalacAllSettings ++ unidocCommonSettings ++
   addCompilerPlugins(libs, "kind-projector") ++ copyrightHeader

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val rootJS = project
   )
 
 
-lazy val core    = prj(coreM)
+lazy val core    = prj(coreM).settings(scala213Setting)
 lazy val coreJVM = coreM.jvm
 lazy val coreJS  = coreM.js
 lazy val coreM   = module("core", CrossType.Pure)
@@ -62,9 +62,7 @@ lazy val lawsM   = module("laws", CrossType.Pure)
   .enablePlugins(AutomateHeaderPlugin)
 
 
-lazy val legacyMacros    = prj(legacyMacrosM).settings(
-  crossScalaVersions := crossScalaVersions.value.filterNot(_ == libs.vers("scalac_2.13"))
-)
+lazy val legacyMacros    = prj(legacyMacrosM)
 lazy val legacyMacrosJVM = legacyMacrosM.jvm
 lazy val legacyMacrosJS  = legacyMacrosM.js
 lazy val legacyMacrosM   = module("legacy-macros", CrossType.Pure)
@@ -74,7 +72,7 @@ lazy val legacyMacrosM   = module("legacy-macros", CrossType.Pure)
   .disablePlugins(DoctestPlugin)
   .enablePlugins(AutomateHeaderPlugin)
 
-lazy val macros    = prj(macrosM)
+lazy val macros    = prj(macrosM).settings(scala213Setting)
 lazy val macrosJVM = macrosM.jvm
 lazy val macrosJS  = macrosM.js
 lazy val macrosM   = module("macros", CrossType.Pure)
@@ -82,7 +80,10 @@ lazy val macrosM   = module("macros", CrossType.Pure)
   .settings(scalaMacroDependencies(libs))
   .settings(copyrightHeader)
   .settings(
-    libs.testDependencies("scalatest", "scalacheck"),
+    libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest" % scalatestVersion(scalaVersion.value) % "test",
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion(scalaVersion.value) % "test"
+    ),
     doctestTestFramework := DoctestTestFramework.ScalaTest
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -173,6 +174,15 @@ lazy val metaMacroSettings: Seq[Def.Setting[_]] = Seq(
   scalacOptions += "-Xplugin-require:macroparadise",
   sources in (Compile, doc) := Nil // macroparadise doesn't work with scaladoc yet.
 )
+
+def scalatestVersion(scalaVersion: String): String =
+  if (priorTo2_13(scalaVersion)) "3.0.5" else "3.0.6-SNAP5"
+
+def scalaCheckVersion(scalaVersion: String): String =
+  if (priorTo2_13(scalaVersion)) "1.13.5" else "1.14.0"
+
+lazy val scala213Setting =
+  crossScalaVersions += libs.vers("scalac_2.13")
 
 lazy val copyrightHeader = Seq(
   startYear := Some(2017),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.typelevel" %% "sbt-catalysts" % "0.11.3")
+addSbtPlugin("org.typelevel" %% "sbt-catalysts" % "0.12")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
 


### PR DESCRIPTION
Note that's we are only running the tiny scaladoc tests on 2.13 for `cats-tagless-macros`. So the test coverage on 2.13 is next to zero. But I think that's okay because 2.13 is still on milestone release, we treat this as a milestone release as well. 