### PR TITLE
Remove unused and unnecessary scala meta code

### DIFF
--- a/legacy-macros/src/main/scala/cats/tagless/autoContravariant.scala
+++ b/legacy-macros/src/main/scala/cats/tagless/autoContravariant.scala
@@ -37,34 +37,6 @@ object autoContravariant {
     import ad._
     import cls._
 
-    class ParamParser(params: Seq[Term.Param]) {
-      lazy val effParams: Seq[Term.Param] =
-        params.collect {
-          case p @ Term.Param(_, _, Some(Type.Name(`effectTypeName`)), _) => p
-        }
-
-      lazy val newArgs: Seq[Term] =
-        params.map {
-          case p if effParams.contains(p) => q"mapFunctionFrom(${Term.Name(p.name.value)})"
-          case p => Term.Name(p.name.value)
-        }
-
-      lazy val newParams: Seq[Term.Param] =
-        params.map { p =>
-          effParams.find(_ == p).fold(p) { effP =>
-            effP.copy(decltpe = Some(Type.Name("TTarget")))
-          }
-        }
-    }
-
-    val methods = templ.stats.toList.flatMap(_.collect {
-      //abstract method with other return type
-      case q"def $methodName[..$mTParams](...$params): $targetType" =>
-        val pps = params.map(new ParamParser(_))
-        q"""def $methodName[..$mTParams](...${pps.map(_.newParams)}): $targetType =
-           delegatee_.$methodName(...${pps.map(_.newArgs)})"""
-    })
-
     val instanceDef = Seq(q"""
       implicit def ${Term.Name("contravariantFor" + name.value)}[..$extraTParams]: _root_.cats.Contravariant[$typeLambdaVaryingEffect] =
         _root_.cats.tagless.Derive.contravariant[$typeLambdaVaryingEffect]

--- a/legacy-macros/src/main/scala/cats/tagless/autoInvariantK.scala
+++ b/legacy-macros/src/main/scala/cats/tagless/autoInvariantK.scala
@@ -39,101 +39,19 @@ class autoInvariantK(autoDerivation: Boolean) extends StaticAnnotation {
 }
 
 
-class InvariantKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) extends FunctorKInstanceGenerator(algDefn) {
+class InvariantKInstanceGenerator(algDefn: AlgDefn, autoDerivation: Boolean) {
   import algDefn._
   import cls._
 
-  case class EffParam(p: Term.Param, tpeArg: Type)
-
-  class ParamParser(params: Seq[Term.Param]) {
-    lazy val effParams: Seq[EffParam] =
-      params.collect {
-        case p @ Term.Param(_, _, Some(Type.Apply(Type.Name(`effectTypeName`), Seq(tpeArg))), _) =>
-          EffParam(p, tpeArg)
-      }
-
-    lazy val newArgs: Seq[Term] =
-      params.map {
-        case p if effParams.exists(_.p == p) => q"gk(${Term.Name(p.name.value)})"
-        case p => Term.Name(p.name.value)
-      }
-
-    lazy val newParams: Seq[Term.Param] =
-      params.map { p =>
-        effParams.find(_.p == p).fold(p) { effP =>
-          effP.p.copy(decltpe = Some(Type.Apply(Type.Name("G"), Seq(effP.tpeArg))))
-        }
-      }
-  }
-
   lazy val instanceDef: Seq[Defn] = {
-    def newMethod(methodName: Term.Name,
-                  params: Seq[Term.Param],
-                  resultType: Type,
-                  mTParams: Seq[Type.Param]): Defn.Def = {
-      val pp = new ParamParser(params)
-
-      if(pp.effParams.isEmpty) {
-        val (newResultType, newImpl) = covariantTransform(resultType, q"af.$methodName(..${arguments(params)})" )
-
-        q"""override def $methodName[..$mTParams](..$params): $newResultType = $newImpl"""
-      } else {
-        val (newResultType, newImpl) = covariantTransform(resultType, q"af.$methodName(..${pp.newArgs})" )
-        q"""override def $methodName[..$mTParams](..${pp.newParams}): $newResultType = $newImpl """
-      }
-    }
-
-    //todo: duplicated with newMethod
-    def newMethodCurry(methodName: Term.Name,
-                  params: Seq[Term.Param],
-                  params2: Seq[Term.Param],
-                  resultType: Type,
-                  mTParams: Seq[Type.Param]): Defn.Def = {
-      val pp = new ParamParser(params)
-      val pp2= new ParamParser(params2)
-
-      if(pp.effParams.isEmpty) {
-        val (newResultType, newImpl) = covariantTransform(resultType, q"af.$methodName(..${arguments(params)})(..${arguments(params2)})" )
-
-        q"""override def $methodName[..$mTParams](..$params)(..$params2): $newResultType = $newImpl"""
-      } else {
-        val (newResultType, newImpl) = covariantTransform(resultType, q"af.$methodName(..${pp.newArgs})(..${pp2.newArgs})" )
-        q"""override def $methodName[..$mTParams](..${pp.newParams})(..${pp2.newParams}): $newResultType = $newImpl """
-      }
-    }
-
-
-    val methods = fromExistingStats {
-      case q"def $methodName[..$mTParams](..$params): $resultType" =>
-        newMethod(methodName, params, resultType, mTParams)
-      case st @ q"def $methodName[..$mTParams](..$params) = $impl" =>
-        abort(s"cats.tagless.autoInvariantK does not support method without declared return type. as in $st ")
-      case q"def $methodName[..$mTParams](..$params): $resultType = $impl"  =>
-        newMethod(methodName, params, resultType.get, mTParams)
-
-      case q"def $methodName[..$mTParams](..$params)(..$params2): $resultType" =>
-        newMethodCurry(methodName, params, params2, resultType, mTParams)
-      case st @ q"def $methodName[..$mTParams](..$params)(..$params2) = $impl" =>
-        abort(s"cats.tagless.autoInvariantK does not support method without declared return type. as in $st ")
-      case q"def $methodName[..$mTParams](..$params)(..$params2): $resultType = $impl"  =>
-        newMethodCurry(methodName, params, params2, resultType.get, mTParams)
-
-    } ++ defWithoutParams
-
     val from = Term.Name("af")
+    val fullyRefinedAlgebra = dependentRefinedTypeSig("G", from)
     //create a mapK method in the companion object with more precise refined type signature
 
-    def newInstance(newTypeMembers: Seq[Defn.Type]): Term.New =
-      q"""
-         new ${Ctor.Ref.Name(name.value)}[..${tArgs("G")}] {
-                  ..$newTypeMembers
-                   ..$methods
-                 }
-       """
     Seq(
       q"""
-        def imapK[F[_], G[_], ..$extraTParams]($from: ${newTypeSig("F")})(fk: _root_.cats.~>[F, G])(gk: _root_.cats.~>[G, F]): ${dependentRefinedTypeSig("G", from)} =
-          ${newInstance(newTypeMember(from))}
+        def imapK[F[_], G[_], ..$extraTParams]($from: ${newTypeSig("F")})(fk: _root_.cats.~>[F, G])(gk: _root_.cats.~>[G, F]): $fullyRefinedAlgebra =
+          _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffect].imapK($from)(fk)(gk).asInstanceOf[$fullyRefinedAlgebra]
       """,
       q"""
         implicit def ${Term.Name("invariantKFor" + name.value)}[..$extraTParams]: _root_.cats.tagless.InvariantK[$typeLambdaVaryingHigherKindedEffect] =

--- a/legacy-macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
+++ b/legacy-macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
@@ -43,31 +43,6 @@ object autoSemigroupalK {
 
     cls.copy(companion = cls.companion.addStats(instanceDef))
   }
-
-  private[tagless] def semigroupalKMethods(cls: TypeDefinition): Defn = {
-    import cls._
-
-    val methods = templ.stats.map(_.map {
-      case q"def $methodName[..$mTParams](..$params): $f[$resultType]" =>
-
-        q"""def $methodName[..$mTParams](..$params): _root_.cats.data.Tuple2K[F, G, $resultType] =
-           _root_.cats.data.Tuple2K(af.$methodName(..${arguments(params)}), ag.$methodName(..${arguments(params)}))"""
-      case q"def $methodName[..$mTParams](..$params)(..$params2): $f[$resultType]" =>
-
-        q"""def $methodName[..$mTParams](..$params)(..$params2): _root_.cats.data.Tuple2K[F, G, $resultType] =
-           _root_.cats.data.Tuple2K(af.$methodName(..${arguments(params)})(..${arguments(params2)}), ag.$methodName(..${arguments(params)})(..${arguments(params2)}))"""
-      case st => abort(s"autoSemigroupalK does not support algebra with such statement: $st")
-    }).getOrElse(Nil)
-
-    q"""
-      def productK[F[_], G[_]](af: $name[F], ag: $name[G]): $name[({type λ[A]=_root_.cats.data.Tuple2K[F, G, A]})#λ] =
-        new ${Ctor.Ref.Name(name.value)}[({type λ[A]=_root_.cats.data.Tuple2K[F, G, A]})#λ] {
-          ..$methods
-        }
-    """
-
-
-  }
 }
 
 


### PR DESCRIPTION
Delegate refined companion object methods to the instance.

This reduces a bit the surface area of code to be ported to `scala.reflect`.