### PR TITLE
Fix DeriveMacros when a higher-kinded refined type is passed as a ref

### DIFF
--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
@@ -217,8 +217,8 @@ object autoFunctorKTests {
 
   object AlgWithTypeMember {
     type Aux[F[_], T0] = AlgWithTypeMember[F] { type T = T0 }
+    Derive.functorK[AlgWithTypeMember { type T = Int }]
   }
-
 
   @autoFunctorK @finalAlg
   trait AlgWithExtraTP[F[_], T] {
@@ -270,6 +270,7 @@ object autoFunctorKTests {
 
   object AlgWithAbstractTypeClass {
     type Aux[F[_], TC0[_]] = AlgWithAbstractTypeClass[F] { type TC[T] = TC0[T] }
+    Derive.functorK[AlgWithAbstractTypeClass { type TC[T] = List[T] }]
   }
 
   @autoFunctorK @finalAlg


### PR DESCRIPTION
One can pass a refined type `Hk[F[_]] { type T }` as a reference:

```scala
Derive.functorK[Hk { type T = Int }]
```

and this currently breaks the derivation.

To resolve the problem we `etaExpand` the type constructor to
obtain a `PolyType` which is easier to work with.

As a cleanup, extract the initial normalization performed on
the algebra type parameter to a helper method.

Discovered by @marcin-rzeznicki as part of #37