### PR TITLE
Generalize autoProductNK macro

### DIFF
--- a/macros/src/main/scala/cats/tagless/MacroUtils.scala
+++ b/macros/src/main/scala/cats/tagless/MacroUtils.scala
@@ -180,10 +180,15 @@ private[tagless] abstract class MacroUtils {
   def tArgs(tparam1: TypeDef, tparam2: TypeDef): List[Ident] = List(tArgs(tparam1), tArgs(tparam2))
   def tArgs(tparams: List[TypeDef]): List[Ident] = tparams.map(tArgs)
 
-  def arguments(params: Seq[Tree]): Seq[TermName] =
+  def arguments(params: Seq[Tree]): Seq[Tree] =
     params.collect {
-      case ValDef(_, name, _, _) => name
+      case ValDef(_, name, AppliedTypeTree(ref: RefTree, _ :: Nil), _)
+        if ref.name == definitions.RepeatedParamClass.name => q"$name: _*"
+      case ValDef(_, name, _, _) => Ident(name)
     }
+
+  def argumentLists(paramLists: Seq[Seq[Tree]]): Seq[Seq[Tree]] =
+    paramLists.map(arguments)
 
   lazy val autoDerive: Boolean = c.prefix.tree match {
     case q"new ${_}(${arg: Boolean})"                  => arg

--- a/macros/src/main/scala/cats/tagless/autoProductNK.scala
+++ b/macros/src/main/scala/cats/tagless/autoProductNK.scala
@@ -45,23 +45,14 @@ private [tagless] class autoProductNKMacros(override val c: whitebox.Context) ex
     val productTypeName = tq"_root_.cats.tagless.${TypeName("Tuple" + arity + "K")}"
 
     val methods = typedef.impl.body.map {
-      case q"def $methodName[..$mTParams](..$params): ${_}[$resultType]" =>
-        val returnItems = range.map { n =>
-          q"${af(n)}.$methodName(..${arguments(params)})"
-        }
-        q"""def $methodName[..$mTParams](..$params): $productTypeName[..$effectTypeParamsNames]#λ[$resultType] =
-           (..$returnItems)"""
-      //curried version
-      case q"def $methodName[..$mTParams](..$params1)(..$params2): ${_}[$resultType]" =>
-        val returnItems = range.map { n =>
-          q"${af(n)}.$methodName(..${arguments(params1)})(..${arguments(params2)})"
-        }
-        q"""def $methodName[..$mTParams](..$params1)(..$params2): $productTypeName[..$effectTypeParamsNames]#λ[$resultType] =
-           (..$returnItems)"""
-      case st =>
-        abort(
-          s"autoProductK does not support algebra with such statement: $st"
-        )
+      case q"def $method[..$typeParams](...$paramLists): ${_}[$resultType]" =>
+        val returnItems = range.map(n => q"${af(n)}.$method(...${argumentLists(paramLists)})")
+        q"""def $method[..$typeParams](...$paramLists): $productTypeName[..$effectTypeParamsNames]#λ[$resultType] =
+           (..$returnItems)
+        """
+
+      case statement =>
+        abort(s"autoProductK does not support algebra with such statement: $statement")
     }
 
     //af1: A[F1], af2: A[F2], af3: A[F3]

--- a/tests/src/test/scala/cats/tagless/tests/autoProductNKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoProductNKTests.scala
@@ -52,7 +52,12 @@ object autoProductNKTests {
   }
 
   @autoProductNK
-  trait algWithCurry[F[_]] {
-    def a(b: String)(c: Int): F[Unit]
+  trait algWithDifferentParameterLists[F[_]] {
+    def parameterLess: F[Unit]
+    def nullary(): F[Unit]
+    def singular(a: String): F[Unit]
+    def binary(a: String)(b: Int): F[Unit]
+    def complex(a: String, b: Int)()(c: Long)(implicit d: Double, e: Char): F[Unit]
+    def varArg(a: String, xs: Int*): F[Unit]
   }
 }


### PR DESCRIPTION
We can handle methods with arbitrary shape of parameter lists by
utilizing the appropriate quasi-quotes syntax.

Also, handle repeated parameters in `arguments`.