### PR TITLE
Optimize typeclass instances for algebras without extra type params

### DIFF
--- a/macros/src/main/scala/cats/tagless/MacroUtils.scala
+++ b/macros/src/main/scala/cats/tagless/MacroUtils.scala
@@ -190,6 +190,10 @@ private[tagless] abstract class MacroUtils {
   def argumentLists(paramLists: Seq[Seq[Tree]]): Seq[Seq[Tree]] =
     paramLists.map(arguments)
 
+  def typeClassInstance(name: TermName, typeParams: Seq[TypeDef], resultType: Tree, rhs: Tree): Tree =
+    if (typeParams.isEmpty) q"implicit val $name: $resultType = $rhs"
+    else q"implicit def $name[..$typeParams]: $resultType = $rhs"
+
   lazy val autoDerive: Boolean = c.prefix.tree match {
     case q"new ${_}(${arg: Boolean})"                  => arg
     case q"new ${_}(autoDerivation = ${arg: Boolean})" => arg

--- a/macros/src/main/scala/cats/tagless/autoFlatMap.scala
+++ b/macros/src/main/scala/cats/tagless/autoFlatMap.scala
@@ -15,12 +15,12 @@
  */
 
 package cats.tagless
+
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
 import scala.reflect.macros.whitebox
 
-/**
-  * auto generates an instance of `cats.FlatMap`
-  */
+/** Auto generates an instance of `cats.FlatMap`. */
 @compileTimeOnly("Cannot expand @autoFlatMap")
 class autoFlatMap extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro autoFlatMapMacros.flatMapInst
@@ -30,17 +30,16 @@ class autoFlatMap extends StaticAnnotation {
 private[tagless] class autoFlatMapMacros(override val c: whitebox.Context) extends MacroUtils {
   import c.universe._
 
-  private def generateFlatMapFor(algebraName: String)(algebraType: Tree,
-                                                    tparams: Seq[TypeDef]) = {
-    val name = TermName("flatMapFor" + algebraName)
-    q"""
-      implicit def $name[..$tparams]: _root_.cats.FlatMap[$algebraType] =
-        _root_.cats.tagless.Derive.flatMap[$algebraType]
-    """
-  }
+  private def generateFlatMapFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("flatMapFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.FlatMap[$algebraType]",
+      q"_root_.cats.tagless.Derive.flatMap[$algebraType]"
+    )
 
   def flatMapInst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false)(
-      ad => ad.forVaryingEffectType(generateFlatMapFor(ad.name))
-    )
+    enrichAlgebra(annottees.toList, higherKinded = false) { algebra =>
+      algebra.forVaryingEffectType(generateFlatMapFor(algebra.name))
+    }
 }

--- a/macros/src/main/scala/cats/tagless/autoFunctorK.scala
+++ b/macros/src/main/scala/cats/tagless/autoFunctorK.scala
@@ -15,12 +15,12 @@
  */
 
 package cats.tagless
+
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
 import scala.reflect.macros.whitebox
 
-/**
-  * auto generates an instance of [[FunctorK]]
-  */
+/** Auto generates an instance of [[FunctorK]]. */
 @compileTimeOnly("Cannot expand @autoFunctorK")
 class autoFunctorK(autoDerivation: Boolean = true) extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro autoFunctorKMacros.newDef
@@ -29,20 +29,16 @@ class autoFunctorK(autoDerivation: Boolean = true) extends StaticAnnotation {
 private [tagless] class autoFunctorKMacros(override val c: whitebox.Context) extends MacroUtils with CovariantKMethodsGenerator {
   import c.universe._
 
-  private def generateFunctorKFor(
-    algebraName: String
-  )(algebraType: Tree, tparams: Seq[TypeDef]) = {
-    val name = TermName("functorKFor" + algebraName)
-    q"""
-        implicit def $name[..$tparams]: _root_.cats.tagless.FunctorK[$algebraType] =
-          _root_.cats.tagless.Derive.functorK[$algebraType]
-      """
-  }
-
-  def instanceDef(algDefn: AlgDefn): AlgDefn =
-    algDefn.forVaryingHigherKindedEffectType(
-      generateFunctorKFor(algDefn.name)
+  private def generateFunctorKFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("functorKFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.tagless.FunctorK[$algebraType]",
+      q"_root_.cats.tagless.Derive.functorK[$algebraType]"
     )
+
+  def instanceDef(algebra: AlgDefn): AlgDefn =
+    algebra.forVaryingHigherKindedEffectType(generateFunctorKFor(algebra.name))
 
   def instanceDefFullyRefined(algDefn: AlgDefn): AlgDefn = {
     algDefn.forVaryingHigherKindedEffectTypeFullyRefined {


### PR DESCRIPTION
In such cases the instance can be an implicit val instead of def.
Define a helper method in `MacroUtils`.