### PR TITLE
Add support for repeated (vararg) parameters

### DIFF
--- a/tests/src/test/scala/cats/tagless/tests/autoApplyKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoApplyKTests.scala
@@ -69,5 +69,9 @@ object autoApplyKTests {
       }
   }
 
+  @autoApplyK
+  trait AlgWithVarArgsParameter[F[_]] {
+    def sum(xs: Int*): Int
+    def fSum(xs: Int*): F[Int]
+  }
 }
-

--- a/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
@@ -97,6 +97,12 @@ object autoContravariantTest {
     def foo(a: T)(b: Int): String
   }
 
+  @autoContravariant
+  trait AlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def showAll(ts: T*): Int
+  }
+
   object AlgWithExtraTypeParamFloat extends AlgWithExtraTypeParam[String, Float] {
     def foo(a: String, b: Float): Int = (a.length.toFloat + b).toInt
   }

--- a/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
@@ -66,6 +66,12 @@ object autoFlatMapTests {
     def plusOne[A](i: A): T
   }
 
+  @autoFlatMap
+  trait AlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def generic[A](as: A*): T
+  }
+
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =
     Eq.by { p =>
       (p.abstractEffect: String => T) ->

--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
@@ -334,4 +334,9 @@ object autoFunctorKTests {
     def log(msg: => String): F[String]
   }
 
+  @autoFunctorK
+  trait AlgWithVarArgsParameter[F[_]] {
+    def sum(xs: Int*): Int
+    def fSum(xs: Int*): F[Int]
+  }
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorTests.scala
@@ -72,6 +72,12 @@ object autoFunctorTests {
     def plusOne[A](i: A): T
   }
 
+  @autoFunctor
+  trait AlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def product(xs: Int*): T
+  }
+
   implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =
     Eq.by { p =>
       (p.abstractEffect: String => T) ->

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
@@ -187,4 +187,12 @@ object autoInvariantKTests {
   trait AlgWithCurryMethod[F[_]] {
     def a(t: F[Int])(b: String): F[String]
   }
+
+  @autoInvariantK
+  trait AlgWithVarArgsParameter[F[_]] {
+    def sum(xs: Int*): Int
+    def covariantSum(xs: Int*): F[Int]
+    def contravariantSum(xs: F[Int]*): Int
+    def invariantSum(xs: F[Int]*): F[Int]
+  }
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
@@ -124,4 +124,12 @@ object autoInvariantTests {
         def foo(i: T): T = f(i)
       }
     }
+
+  @autoInvariant
+  trait AlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def covariantSum(xs: Int*): T
+    def contravariantSum(xs: T*): Int
+    def invariantSum(xs: T*): T
+  }
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoSemigroupalKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoSemigroupalKTests.scala
@@ -53,6 +53,10 @@ object autoSemigroupalKTests {
     def a(b: String)(d: Int): F[Unit]
   }
 
-
+  @autoSemigroupalK
+  trait AlgWithVarArgsParameter[F[_]] {
+    def sum(xs: Int*): Int
+    def effectfulSum(xs: Int*): F[Int]
+  }
 }
 


### PR DESCRIPTION
They require special handling because they are modelled as a
magic type constructor `<repeated>[T]` in the compiler.

Fixes #53 

I can add compile tests about other typeclasses later.
I'm not sure if this needs runtime tests?