### PR TITLE
Flexible derivation based on existing instances + Instances for cats.data

### DIFF
--- a/core/src/main/scala/cats/tagless/instances/AllInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/AllInstances.scala
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+trait AllInstances extends EitherKInstances
+  with EitherTInstances
+  with FuncInstances
+  with IdTInstances
+  with IorTInstances
+  with KleisliInstances
+  with NestedInstances
+  with OneAndInstances
+  with OptionTInstances
+  with Tuple2KInstances
+  with WriterTInstances

--- a/core/src/main/scala/cats/tagless/instances/EitherKInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/EitherKInstances.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.instances
+
+import cats.data.{EitherK, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait EitherKInstances {
+
+  implicit def catsTaglessApplyKForEitherK[F[_], A]: ApplyK[EitherK[F, ?[_], A]] =
+    eitherKInstance.asInstanceOf[ApplyK[EitherK[F, ?[_], A]]]
+
+  private[this] val eitherKInstance: ApplyK[EitherK[Any, ?[_], Any]] = new ApplyK[EitherK[Any, ?[_], Any]] {
+    def mapK[F[_], G[_]](af: EitherK[Any, F, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: EitherK[Any, F, Any], ag: EitherK[Any, G, Any]) =
+      (af.run, ag.run) match {
+        case (Left(x), _) => EitherK.leftc[Any, Tuple2K[F, G, ?], Any](x)
+        case (_, Left(y)) => EitherK.leftc[Any, Tuple2K[F, G, ?], Any](y)
+        case (Right(fa), Right(ga)) => EitherK.rightc[Any, Tuple2K[F, G, ?], Any](Tuple2K(fa, ga))
+      }
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/EitherTInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/EitherTInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{EitherT, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait EitherTInstances {
+
+  implicit def catsTaglessApplyKForEitherT[A, B]: ApplyK[EitherT[?[_], A, B]] =
+    eitherTInstance.asInstanceOf[ApplyK[EitherT[?[_], A, B]]]
+
+  private[this] val eitherTInstance: ApplyK[EitherT[?[_], Any, Any]] = new ApplyK[EitherT[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: EitherT[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: EitherT[F, Any, Any], ag: EitherT[G, Any, Any]) =
+      EitherT(Tuple2K(af.value, ag.value))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/FuncInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/FuncInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{Func, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait FuncInstances {
+
+  implicit def catsTaglessApplyKForFunc[A, B]: ApplyK[Func[?[_], A, B]] =
+    funcInstance.asInstanceOf[ApplyK[Func[?[_], A, B]]]
+
+  private[this] val funcInstance: ApplyK[Func[?[_], Any, Any]] = new ApplyK[Func[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: Func[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: Func[F, Any, Any], ag: Func[G, Any, Any]) =
+      Func.func(x => Tuple2K(af.run(x), ag.run(x)))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/IdTInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/IdTInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{IdT, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait IdTInstances {
+
+  implicit def catsTaglessApplyKForIdT[A]: ApplyK[IdT[?[_], A]] =
+    idTInstance.asInstanceOf[ApplyK[IdT[?[_], A]]]
+
+  private[this] val idTInstance: ApplyK[IdT[?[_], Any]] = new ApplyK[IdT[?[_], Any]] {
+    def mapK[F[_], G[_]](af: IdT[F, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: IdT[F, Any], ag: IdT[G, Any]) =
+      IdT(Tuple2K(af.value, ag.value))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/IorTInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/IorTInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{IorT, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait IorTInstances {
+
+  implicit def catsTaglessApplyKForIorT[A, B]: ApplyK[IorT[?[_], A, B]] =
+    iOrTInstance.asInstanceOf[ApplyK[IorT[?[_], A, B]]]
+
+  private[this] val iOrTInstance: ApplyK[IorT[?[_], Any, Any]] = new ApplyK[IorT[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: IorT[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: IorT[F, Any, Any], ag: IorT[G, Any, Any]) =
+      IorT(Tuple2K(af.value, ag.value))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/KleisliInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/KleisliInstances.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.instances
+
+import cats.data.{Kleisli, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait KleisliInstances {
+
+  implicit def catsTaglessApplyKForKleisli[A, B]: ApplyK[Kleisli[?[_], A, B]] =
+    kleisliInstance.asInstanceOf[ApplyK[Kleisli[?[_], A, B]]]
+
+  private[this] val kleisliInstance: ApplyK[Kleisli[?[_], Any, Any]] = new ApplyK[Kleisli[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: Kleisli[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: Kleisli[F, Any, Any], ag: Kleisli[G, Any, Any]) =
+      Kleisli(x => Tuple2K(af.run(x), ag.run(x)))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/NestedInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/NestedInstances.scala
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.Nested
+import cats.tagless.FunctorK
+import cats.~>
+
+trait NestedInstances {
+
+  implicit def catsTaglessFunctorKForNested[G[_], A]: FunctorK[Nested[?[_], G, A]] =
+    nestedInstance.asInstanceOf[FunctorK[Nested[?[_], G, A]]]
+
+  private[this] val nestedInstance: FunctorK[Nested[?[_], Any, Any]] = new FunctorK[Nested[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: Nested[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/OneAndInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/OneAndInstances.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.instances
+
+import cats.data.{OneAnd, Tuple2K}
+import cats.tagless.{ApplyK, FunctorK}
+import cats.{Semigroup, ~>}
+
+trait OneAndInstances extends OneAndInstances1 {
+  implicit def catsTaglessApplyKForOneAnd[A: Semigroup]: ApplyK[OneAnd[?[_], A]] = new ApplyK[OneAnd[?[_], A]] {
+    def mapK[F[_], G[_]](af: OneAnd[F, A])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: OneAnd[F, A], ag: OneAnd[G, A]) =
+      OneAnd(Semigroup[A].combine(af.head, ag.head), Tuple2K(af.tail, ag.tail))
+  }
+}
+
+private[instances] trait OneAndInstances1 {
+
+  implicit def catsTaglessFunctorKForOneAnd[A]: FunctorK[OneAnd[?[_], A]] =
+    oneAndFunctorK.asInstanceOf[FunctorK[OneAnd[?[_], A]]]
+
+  private[this] val oneAndFunctorK: FunctorK[OneAnd[?[_], Any]] = new FunctorK[OneAnd[?[_], Any]] {
+    def mapK[F[_], G[_]](af: OneAnd[F, Any])(fk: F ~> G) = af.mapK(fk)
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/OptionTInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/OptionTInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{OptionT, Tuple2K}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait OptionTInstances {
+
+  implicit def catsTaglessApplyKForOptionT[A]: ApplyK[OptionT[?[_], A]] =
+    optionTInstance.asInstanceOf[ApplyK[OptionT[?[_], A]]]
+
+  private[this] val optionTInstance: ApplyK[OptionT[?[_], Any]] = new ApplyK[OptionT[?[_], Any]] {
+    def mapK[F[_], G[_]](af: OptionT[F, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: OptionT[F, Any], ag: OptionT[G, Any]) =
+      OptionT(Tuple2K(af.value, ag.value))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/Tuple2KInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/Tuple2KInstances.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.instances
+
+import cats.data.Tuple2K
+import cats.tagless.{ApplyK, FunctorK}
+import cats.{SemigroupK, ~>}
+
+trait Tuple2KInstances extends Tuple2KInstances1 {
+  implicit def catsTaglessApplyKForTuple2K[H[_]: SemigroupK, A]: ApplyK[Tuple2K[H, ?[_], A]] =
+    new ApplyK[Tuple2K[H, ?[_], A]] {
+      def mapK[F[_], G[_]](af: Tuple2K[H, F, A])(fk: F ~> G) = af.mapK(fk)
+      def productK[F[_], G[_]](af: Tuple2K[H, F, A], ag: Tuple2K[H, G, A]) =
+        Tuple2K(SemigroupK[H].combineK(af.first, ag.first), Tuple2K(af.second, ag.second))
+    }
+}
+
+private[instances] trait Tuple2KInstances1 {
+
+  implicit def catsTaglessFunctorKForTuple2K[F[_], A]: FunctorK[Tuple2K[F, ?[_], A]] =
+    tuple2KFunctorK.asInstanceOf[FunctorK[Tuple2K[F, ?[_], A]]]
+
+  private[this] val tuple2KFunctorK: FunctorK[Tuple2K[Any, ?[_], Any]] = new FunctorK[Tuple2K[Any, ?[_], Any]] {
+    def mapK[F[_], G[_]](af: Tuple2K[Any, F, Any])(fk: F ~> G) = af.mapK(fk)
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/WriterTInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/WriterTInstances.scala
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-package cats.tagless
+package cats.tagless.instances
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+import cats.data.{Tuple2K, WriterT}
+import cats.tagless.ApplyK
+import cats.~>
+
+trait WriterTInstances {
+
+  implicit def catsTaglessApplyKForWriterT[A, B]: ApplyK[WriterT[?[_], A, B]] =
+    writerTInstance.asInstanceOf[ApplyK[WriterT[?[_], A, B]]]
+
+  private[this] val writerTInstance: ApplyK[WriterT[?[_], Any, Any]] = new ApplyK[WriterT[?[_], Any, Any]] {
+    def mapK[F[_], G[_]](af: WriterT[F, Any, Any])(fk: F ~> G) = af.mapK(fk)
+    def productK[F[_], G[_]](af: WriterT[F, Any, Any], ag: WriterT[G, Any, Any]) =
+      WriterT(Tuple2K(af.run, ag.run))
+  }
+}

--- a/core/src/main/scala/cats/tagless/instances/package.scala
+++ b/core/src/main/scala/cats/tagless/instances/package.scala
@@ -16,4 +16,17 @@
 
 package cats.tagless
 
-package object implicits extends instances.AllInstances with syntax.AllSyntax
+package object instances {
+  object all extends AllInstances
+  object eitherK extends EitherKInstances
+  object eitherT extends EitherTInstances
+  object func extends FuncInstances
+  object idT extends IdTInstances
+  object iorT extends IorTInstances
+  object kleisli extends KleisliInstances
+  object nested extends NestedInstances
+  object oneAnd extends OneAndInstances
+  object optionT extends OptionTInstances
+  object tuple2K extends Tuple2KInstances
+  object writerT extends WriterTInstances
+}

--- a/core/src/main/scala/cats/tagless/package.scala
+++ b/core/src/main/scala/cats/tagless/package.scala
@@ -16,7 +16,10 @@
 
 package cats
 
+import cats.data.Tuple2K
+
 package object tagless {
+  type IdK[A] = { type λ[F[_]] = F[A] }
   type Tuple3K[F[_], G[_], H[_]] = { type λ[T] = (F[T], G[T], H[T]) }
   type Tuple4K[F[_], G[_], H[_], I[_]] = { type λ[T] = (F[T], G[T], H[T], I[T])}
   type Tuple5K[F[_], G[_], H[_], I[_], J[_]] = { type λ[T] = (F[T], G[T], H[T], I[T], J[T])}
@@ -24,4 +27,12 @@ package object tagless {
   type Tuple7K[F[_], G[_], H[_], I[_], J[_], K[_], L[_]] = { type λ[T] = (F[T], G[T], H[T], I[T], J[T], K[T], L[T])}
   type Tuple8K[F[_], G[_], H[_], I[_], J[_], K[_], L[_], M[_]] = { type λ[T] = (F[T], G[T], H[T], I[T], J[T], K[T], L[T], M[T])}
   type Tuple9K[F[_], G[_], H[_], I[_], J[_], K[_], L[_], M[_], N[_]] = { type λ[T] = (F[T], G[T], H[T], I[T], J[T], K[T], L[T], M[T], N[T])}
+
+  implicit def catsTaglessApplyKForIdK[A]: ApplyK[IdK[A]#λ] =
+    idKInstance.asInstanceOf[ApplyK[IdK[A]#λ]]
+
+  private[this] val idKInstance: ApplyK[IdK[Any]#λ] = new ApplyK[IdK[Any]#λ] {
+    def mapK[F[_], G[_]](af: F[Any])(fk: F ~> G) = fk(af)
+    def productK[F[_], G[_]](af: F[Any], ag: G[Any]) = Tuple2K(af, ag)
+  }
 }

--- a/core/src/main/scala/cats/tagless/syntax/AllSyntax.scala
+++ b/core/src/main/scala/cats/tagless/syntax/AllSyntax.scala
@@ -18,5 +18,6 @@ package cats.tagless
 package syntax
 
 trait AllSyntax extends FunctorKSyntax
- with SemigroupalKSyntax
- with InvariantKSyntax
+  with InvariantKSyntax
+  with SemigroupalKSyntax
+  with ApplyKSyntax

--- a/core/src/main/scala/cats/tagless/syntax/package.scala
+++ b/core/src/main/scala/cats/tagless/syntax/package.scala
@@ -21,4 +21,5 @@ package object syntax {
   object functorK extends FunctorKSyntax
   object invariantK extends InvariantKSyntax
   object semigroupalK extends SemigroupalKSyntax
+  object applyK extends ApplyKSyntax
 }

--- a/macros/src/main/scala/cats/tagless/DeriveMacros.scala
+++ b/macros/src/main/scala/cats/tagless/DeriveMacros.scala
@@ -27,45 +27,60 @@ class DeriveMacros(val c: blackbox.Context) {
   import c.universe._
 
   /** A reified method definition with some useful methods for transforming it. */
-  case class Method(m: MethodSymbol, tps: List[TypeDef], pss: List[List[ValDef]], rt: Type, body: Tree) {
+  case class Method(
+    name: TermName,
+    signature: Type,
+    typeParams: List[TypeDef],
+    paramLists: List[List[ValDef]],
+    returnType: Type,
+    body: Tree
+  ) {
 
-    /** Does any parameter have `symbol` as the outermost type (possibly higher-kinded)? */
-    def paramsContainTopLevel(symbol: Symbol): Boolean =
-      pss.exists(_.exists(_.tpt.tpe match {
-        case RepeatedParam(tpe) => tpe.typeSymbol == symbol
-        case tpe => tpe.typeSymbol == symbol
-      }))
+    def occursInSignature(symbol: Symbol): Boolean = occursIn(signature)(symbol)
+    def occursInReturn(symbol: Symbol): Boolean = occursIn(returnType)(symbol)
 
-    /** Return the list of type parameters as type arguments as seen from the method body. */
-    def typeArgs: List[Type] = for (tp <- tps) yield typeRef(NoPrefix, tp.symbol, Nil)
-
-    /** Construct a new set of parameter lists after transforming the original types. */
-    def paramLists(f: Type => Type): List[List[ValDef]] = {
-      val g: Type => Type = {
-        case RepeatedParam(tpe) => RepeatedParam(f(tpe))
-        case tpe => f(tpe)
-      }
-
-      for (ps <- pss) yield for (p <- ps)
-        yield ValDef(p.mods, p.name, TypeTree(g(p.tpt.tpe)), p.rhs)
-    }
+    /** Construct a new set of parameter lists after substituting some type symbols. */
+    def transformedParamLists(from: List[Symbol], to: List[Symbol]): List[List[ValDef]] =
+      for (ps <- paramLists) yield for (p <- ps)
+        yield ValDef(p.mods, p.name, TypeTree(p.tpt.tpe.substituteSymbols(from, to)), p.rhs)
 
     /** Construct a new set of argument lists based on their name and type. */
-    def argLists(f: (TermName, Type) => Tree): List[List[Tree]] = {
-      val g: (TermName, Type) => Tree = {
-        case (name, RepeatedParam(tpe)) =>
-          val param = ValDef(Modifiers(Flag.PARAM), name, TypeTree(), EmptyTree)
-          q"$name.map($param => ${f(name, tpe)}): _*"
-        case (name, tpe) =>
-          f(name, tpe)
+    def transformedArgLists(f: PartialFunction[(TermName, Type), Tree]): List[List[Tree]] = {
+      val id: ((TermName, Type)) => Tree = {
+        case (pn, _) => Ident(pn)
       }
 
-      for (ps <- pss) yield for (p <- ps) yield g(p.name, p.tpt.tpe)
+      val f_* : (TermName, Type) => Tree = {
+        case (pn, RepeatedParam(pt)) =>
+          q"${f.andThen(arg => q"for ($pn <- $pn) yield $arg").applyOrElse(pn -> pt, id)}: _*"
+        case (pn, pt) =>
+          f.applyOrElse(pn -> pt, id)
+      }
+
+      for (ps <- paramLists) yield for (p <- ps)
+        yield f_*(p.name, p.tpt.tpe)
     }
-    def actualArgs = argLists((pn, _) => Ident(pn))
+
+    /** Transform this method into another by applying transformations to types, arguments and body. */
+    def transform(instance: Symbol, types: (Symbol, Symbol)*)(
+      argLists: PartialFunction[(TermName, Type), Tree]
+    )(body: PartialFunction[Tree, Tree]): Method = {
+      val (from, to) = types.toList.unzip
+      copy(
+        paramLists = transformedParamLists(from, to),
+        returnType = returnType.substituteSymbols(from, to),
+        body = body.applyOrElse(delegate(Ident(instance), transformedArgLists(argLists)), identity[Tree])
+      )
+    }
+
+    /** Delegate this method to an existing instance, optionally providing different argument lists. */
+    def delegate(to: Tree, argLists: List[List[Tree]] = transformedArgLists(PartialFunction.empty)): Tree = {
+      val typeArgs = for (tp <- typeParams) yield typeRef(NoPrefix, tp.symbol, Nil)
+      q"$to.$name[..$typeArgs](...$argLists)"
+    }
 
     /** The definition of this method as a Scala tree. */
-    def definition: Tree = q"override def ${m.name}[..$tps](...$pss): $rt = $body"
+    def definition: Tree = q"override def $name[..$typeParams](...$paramLists): $returnType = $body"
   }
 
   /** Constructor / extractor for repeated parameter (aka. vararg) types. */
@@ -77,10 +92,6 @@ class DeriveMacros(val c: blackbox.Context) {
     def unapply(tpe: Type): Option[Type] =
       if (tpe.typeSymbol == definitions.RepeatedParamClass) Some(tpe.typeArgs.head) else None
   }
-
-  /** Extract a normalized type constructor from the type tag, suitable to work with in macros. */
-  def normalizedTypeConstructor(tag: WeakTypeTag[_]): Type =
-    tag.tpe.typeConstructor.dealias.etaExpand
 
   /** Return the set of overridable members of `tpe`, excluding some undesired cases. */
   // TODO: Figure out what to do about different visibility modifiers.
@@ -112,6 +123,18 @@ class DeriveMacros(val c: blackbox.Context) {
     typed
   }
 
+  /** Abort with a message at the current compiler position. */
+  def abort(message: String): Nothing = c.abort(c.enclosingPosition, message)
+
+  /** `tpe.contains` is broken before Scala 2.13. See scala/scala#6122. */
+  def occursIn(tpe: Type)(symbol: Symbol): Boolean = tpe.exists(_.typeSymbol == symbol)
+
+  /** Summon an implicit instance of `A`'s type constructor applied to `typeArgs` if one exists in scope. */
+  def summon[A: TypeTag](typeArgs: Type*): Tree = {
+    val tpe = appliedType(typeOf[A].typeConstructor, typeArgs: _*)
+    c.inferImplicitValue(tpe).orElse(abort(s"could not find implicit value of type $tpe"))
+  }
+
   /** Delegate the definition of type members and aliases in `algebra`. */
   def delegateTypes(algebra: Type, members: Iterable[Symbol])(rhs: (TypeSymbol, List[Type]) => Type): Iterable[Tree] =
     for (member <- members if member.isType) yield {
@@ -130,8 +153,8 @@ class DeriveMacros(val c: blackbox.Context) {
   def delegateMethods(algebra: Type, members: Iterable[Symbol], instance: Symbol)(
     transform: PartialFunction[Method, Method]
   ): Iterable[Tree] = for (member <- members if member.isMethod && !member.asMethod.isAccessor) yield {
-    val method = member.asMethod
-    val signature = method.typeSignatureIn(algebra)
+    val name = member.name.toTermName
+    val signature = member.typeSignatureIn(algebra)
     val typeParams = for (tp <- signature.typeParams) yield typeDef(tp)
     val typeArgs = for (tp <- signature.typeParams) yield typeRef(NoPrefix, tp, Nil)
     val paramLists = for (ps <- signature.paramLists) yield for (p <- ps) yield {
@@ -146,49 +169,49 @@ class DeriveMacros(val c: blackbox.Context) {
         case _ => Ident(p.name)
       }
 
-    val delegate = q"$instance.$method[..$typeArgs](...$argLists)"
-    val reified = Method(method, typeParams, paramLists, signature.finalResultType, delegate)
+    val body = q"$instance.$name[..$typeArgs](...$argLists)"
+    val reified = Method(name, signature, typeParams, paramLists, signature.finalResultType, body)
     transform.applyOrElse(reified, identity[Method]).definition
   }
 
   /** Type-check a definition of type `instance` with stubbed methods to gain more type information. */
   def declare(instance: Type): Tree = {
-    val stubs = delegateMethods(instance, overridableMembersOf(instance).filter(_.isAbstract), NoSymbol) {
-      case method => method.copy(body = q"_root_.scala.Predef.???")
-    }
-
+    val members = overridableMembersOf(instance).filter(_.isAbstract)
+    val stubs = delegateMethods(instance, members, NoSymbol) { case m => m.copy(body = q"_root_.scala.Predef.???") }
     val Block(List(declaration), _) = typeCheckWithFreshTypeParams(q"new $instance { ..$stubs }")
     declaration
   }
 
   /** Implement a possibly refined `algebra` with the provided `members`. */
-  def implement(algebra: Type, members: Iterable[Tree]): Tree = {
+  def implement(algebra: Type)(typeArgs: Symbol*)(members: Iterable[Tree]): Tree = {
     // If `members.isEmpty` we need an extra statement to ensure the generation of an anonymous class.
     val nonEmptyMembers = if (members.isEmpty) q"()" :: Nil else members
+    val applied = appliedType(algebra, typeArgs.toList.map(_.asType.toTypeConstructor))
 
-    algebra match {
+    applied match {
       case RefinedType(parents, scope) =>
-        val refinements = delegateTypes(algebra, scope.filterNot(_.isAbstract)) {
-          (tpe, _) => tpe.typeSignatureIn(algebra).resultType
+        val refinements = delegateTypes(applied, scope.filterNot(_.isAbstract)) {
+          (tpe, _) => tpe.typeSignatureIn(applied).resultType
         }
 
         q"new ..$parents { ..$refinements; ..$nonEmptyMembers }"
       case _ =>
-        q"new $algebra { ..$nonEmptyMembers }"
+        q"new $applied { ..$nonEmptyMembers }"
     }
   }
 
   /** Create a new instance of `typeClass` for `algebra`.
     * `rhs` should define a mapping for each method (by name) to an implementation function based on type signature.
     */
-  def instantiate(typeClass: TypeSymbol, algebra: Type)(rhs: (String, Type => Tree)*): Tree = {
-    val impl = rhs.toMap
-    val TcA = appliedType(typeClass, algebra)
-    val declaration @ ClassDef(_, _, _, Template(parents, self, members)) = declare(TcA)
+  def instantiate[T: WeakTypeTag](tag: WeakTypeTag[_])(rhs: (Type => (String, Type => Tree))*): Tree = {
+    val algebra = tag.tpe.typeConstructor.dealias.etaExpand
+    val Ta = appliedType(symbolOf[T], algebra)
+    val impl = rhs.map(_.apply(algebra)).toMap
+    val declaration @ ClassDef(_, _, _, Template(parents, self, members)) = declare(Ta)
     val implementations = for (member <- members) yield member match {
       case dd: DefDef =>
         val method = member.symbol.asMethod
-        impl.get(method.name.toString).fold(dd)(f => defDef(method, f(method.typeSignatureIn(TcA))))
+        impl.get(method.name.toString).fold(dd)(f => defDef(method, f(method.typeSignatureIn(Ta))))
       case other => other
     }
 
@@ -197,55 +220,110 @@ class DeriveMacros(val c: blackbox.Context) {
   }
 
   // def map[A, B](fa: F[A])(f: A => B): F[B]
+  def map(algebra: Type): (String, Type => Tree) =
+    "map" -> { case PolyType(List(a, b), MethodType(List(fa), MethodType(List(f), _))) =>
+      val Fa = singleType(NoPrefix, fa)
+      val members = overridableMembersOf(Fa)
+      val types = delegateAbstractTypes(Fa, members, Fa)
+      val methods = delegateMethods(Fa, members, fa) {
+        case method if method.occursInSignature(a) =>
+          method.transform(fa, a -> b) {
+            case (pn, pt) if occursIn(pt)(a) =>
+              val F = summon[Contravariant[Any]](polyType(a :: Nil, pt))
+              q"$F.contramap[$b, $a]($pn)($f)"
+          } {
+            case delegate if method.occursInReturn(a) =>
+              val F = summon[Functor[Any]](polyType(a :: Nil, method.returnType))
+              q"$F.map[$a, $b]($delegate)($f)"
+          }
+      }
+
+      implement(algebra)(b)(types ++ methods)
+    }
+
   // def mapK[F[_], G[_]](af: A[F])(fk: F ~> G): A[G]
   def mapK(algebra: Type): (String, Type => Tree) =
     "mapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
       val Af = singleType(NoPrefix, af)
       val members = overridableMembersOf(Af)
       val types = delegateAbstractTypes(Af, members, Af)
-      val methods = delegateMethods(Af, members, af.asTerm) {
-        case method @ Method(_, _, _, rt, delegate) if rt.typeSymbol == f =>
-          method.copy(rt = appliedType(g, rt.typeArgs), body = q"$fk($delegate)")
+      val methods = delegateMethods(Af, members, af) {
+        case method if method.occursInReturn(f) =>
+          method.transform(af, f -> g)(PartialFunction.empty) { case delegate =>
+            val F = summon[FunctorK[Any]](polyType(f :: Nil, method.returnType))
+            q"$F.mapK[$f, $g]($delegate)($fk)"
+          }
+        case method if method.occursInSignature(f) =>
+          abort(s"Type parameter $f appears in contravariant position in method ${method.name}")
       }
 
-      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+      implement(algebra)(g)(types ++ methods)
     }
 
   // def contramap[A, B](fa: F[A])(f: B => A): F[B]
-  def contramapK(algebra: Type): (String, Type => Tree) =
-    "contramapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
-      val Af = singleType(NoPrefix, af)
-      val members = overridableMembersOf(Af)
-      val types = delegateAbstractTypes(Af, members, Af)
-      val methods = delegateMethods(Af, members, af.asTerm) {
-        case method @ Method(m, _, _, _, _) if method.paramsContainTopLevel(f) =>
-          val paramLists = method.paramLists(tpe => if (tpe.typeSymbol == f) appliedType(g, tpe.typeArgs) else tpe)
-          val argLists = method.argLists((pn, pt) => if (pt.typeSymbol == f) q"$fk($pn)" else Ident(pn))
-          val delegate = q"$af.$m[..${method.typeArgs}](...$argLists)"
-          method.copy(pss = paramLists, body = delegate)
+  def contramap(algebra: Type): (String, Type => Tree) =
+    "contramap" -> { case PolyType(List(a, b), MethodType(List(fa), MethodType(List(f), _))) =>
+      val Fa = singleType(NoPrefix, fa)
+      val members = overridableMembersOf(Fa)
+      val types = delegateAbstractTypes(Fa, members, Fa)
+      val methods = delegateMethods(Fa, members, fa) {
+        case method if method.occursInSignature(a) =>
+          method.transform(fa, a -> b) {
+            case (pn, pt) if occursIn(pt)(a) =>
+              val F = summon[Functor[Any]](polyType(a :: Nil, pt))
+              q"$F.map[$b, $a]($pn)($f)"
+          } {
+            case delegate if method.occursInReturn(a) =>
+              val F = summon[Contravariant[Any]](polyType(a :: Nil, method.returnType))
+              q"$F.contramap[$a, $b]($delegate)($f)"
+          }
       }
 
-      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+      implement(algebra)(b)(types ++ methods)
     }
 
   // def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B]
+  def imap(algebra: Type): (String, Type => Tree) =
+    "imap" -> { case PolyType(List(a, b), MethodType(List(fa), MethodType(List(f), MethodType(List(g), _)))) =>
+      val Fa = singleType(NoPrefix, fa)
+      val members = overridableMembersOf(Fa)
+      val types = delegateAbstractTypes(Fa, members, Fa)
+      val methods = delegateMethods(Fa, members, fa) {
+        case method if method.occursInSignature(a) =>
+          method.transform(fa, a -> b) {
+            case (pn, pt) if occursIn(pt)(a) =>
+              val F = summon[Invariant[Any]](polyType(a :: Nil, pt))
+              q"$F.imap[$b, $a]($pn)($g)($f)"
+          } {
+            case delegate if method.occursInReturn(a) =>
+              val F = summon[Invariant[Any]](polyType(a :: Nil, method.returnType))
+              q"$F.imap[$a, $b]($delegate)($f)($g)"
+          }
+      }
+
+      implement(algebra)(b)(types ++ methods)
+    }
+
   // def imapK[F[_], G[_]](af: A[F])(fk: F ~> G)(gK: G ~> F): A[G]
   def imapK(algebra: Type): (String, Type => Tree) =
     "imapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), MethodType(List(gk), _)))) =>
       val Af = singleType(NoPrefix, af)
       val members = overridableMembersOf(Af)
       val types = delegateAbstractTypes(Af, members, Af)
-      val methods = delegateMethods(Af, members, af.asTerm) {
-        case method @ Method(m, _, _, rt, _) if rt.typeSymbol == f || method.paramsContainTopLevel(f) =>
-          val paramLists = method.paramLists(tpe => if (tpe.typeSymbol == f) appliedType(g, tpe.typeArgs) else tpe)
-          val argLists = method.argLists((pn, pt) => if (pt.typeSymbol == f) q"$gk($pn)" else Ident(pn))
-          val returnType = if (rt.typeSymbol == f) appliedType(g, rt.typeArgs) else rt
-          val delegate = q"$af.$m[..${method.typeArgs}](...$argLists)"
-          val body = if (rt.typeSymbol == f) q"$fk($delegate)" else delegate
-          method.copy(pss = paramLists, rt = returnType, body = body)
+      val methods = delegateMethods(Af, members, af) {
+        case method if method.occursInSignature(f) =>
+          method.transform(af, f -> g) {
+            case (pn, pt) if occursIn(pt)(f) =>
+              val F = summon[InvariantK[Any]](polyType(f :: Nil, pt))
+              q"$F.imapK[$g, $f]($pn)($gk)($fk)"
+          } {
+            case delegate if method.occursInReturn(f) =>
+              val F = summon[InvariantK[Any]](polyType(f :: Nil, method.returnType))
+              q"$F.imapK[$f, $g]($delegate)($fk)($gk)"
+          }
       }
 
-      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+      implement(algebra)(g)(types ++ methods)
     }
 
   // def productK[F[_], G[_]](af: A[F], ag: A[G]): A[Tuple2K[F, G, ?]]
@@ -254,67 +332,70 @@ class DeriveMacros(val c: blackbox.Context) {
     "productK" -> { case PolyType(List(f, g), MethodType(List(af, ag), _)) =>
       val F = f.asType.toTypeConstructor
       val G = g.asType.toTypeConstructor
+      val t2k = polyType(F.typeParams, appliedType(Tuple2K, F :: G :: F.typeParams.map(_.asType.toType)))
       val Af = singleType(NoPrefix, af)
       val members = overridableMembersOf(Af)
       val types = delegateAbstractTypes(Af, members, Af)
-      val methods = delegateMethods(Af, members, af.asTerm) {
-        case method @ Method(m, _, _, rt, delegate) if rt.typeSymbol == f =>
-          val FGA = F :: G :: rt.typeArgs
-          val returnType = appliedType(Tuple2K, FGA)
-          val body = q"new $Tuple2K[..$FGA]($delegate, $ag.$m[..${method.typeArgs}](...${method.actualArgs}))"
-          method.copy(rt = returnType, body = body)
+      val methods = delegateMethods(Af, members, af) {
+        case method if method.occursInReturn(f) =>
+          val returnType = method.returnType.map(t => if (t.typeSymbol == f) appliedType(t2k, t.typeArgs) else t)
+          val Sk = summon[SemigroupalK[Any]](polyType(f :: Nil, method.returnType))
+          val body = q"$Sk.productK[$F, $G](${method.delegate(q"$af")}, ${method.delegate(q"$ag")})"
+          method.copy(returnType = returnType, body = body)
+        case method if method.occursInSignature(f) =>
+          abort(s"Type parameter $f appears in contravariant position in method ${method.name}")
       }
 
       val typeParams = Tuple2K.typeParams.drop(2)
       val typeArgs = F :: G :: typeParams.map(_.asType.toType)
-      val T2kAlg = appliedType(algebra, polyType(typeParams, appliedType(Tuple2K, typeArgs)))
-      implement(T2kAlg, types ++ methods)
+      val Tuple2kAlg = appliedType(algebra, polyType(typeParams, appliedType(Tuple2K, typeArgs)))
+      implement(Tuple2kAlg)()(types ++ methods)
     }
   }
 
   // def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
-  def flatMapK(algebra: Type): (String, Type => Tree) =
-    "flatMapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
-      val Af = singleType(NoPrefix, af)
-      val members = overridableMembersOf(Af)
-      val types = delegateAbstractTypes(Af, members, Af)
-      val methods = delegateMethods(Af, members, af.asTerm) {
-        case method @ Method(m, _, _, rt, delegate) if rt.typeSymbol == f =>
-          val body = q"$fk($delegate).$m[..${method.typeArgs}](...${method.actualArgs})"
-          method.copy(rt = appliedType(g, rt.typeArgs), body = body)
+  def flatMap_(algebra: Type): (String, Type => Tree) =
+    "flatMap" -> { case PolyType(List(a, b), MethodType(List(fa), MethodType(List(f), _))) =>
+      val Fa = singleType(NoPrefix, fa)
+      val members = overridableMembersOf(Fa)
+      val types = delegateAbstractTypes(Fa, members, Fa)
+      val methods = delegateMethods(Fa, members, fa) {
+        case method if method.returnType.typeSymbol == a =>
+          val body = method.delegate(q"$f(${method.body})")
+          method.copy(returnType = b.asType.toType, body = body)
+        case method if method.occursInSignature(a) =>
+          abort(s"Type parameter $a can only appear as a top level return type in method ${method.name}")
       }
 
-      implement(appliedType(algebra, g.asType.toTypeConstructor), types ++ methods)
+      implement(algebra)(b)(types ++ methods)
     }
 
-  // def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B]
+  // def tailRecM[A, B](x: A)(f: A => F[Either[A, B]]): F[B]
   def tailRecM(algebra: Type): (String, Type => Tree) =
     "tailRecM" -> { case PolyType(List(a, b), MethodType(List(x), MethodType(List(f), _))) =>
       val Fa = appliedType(algebra, a.asType.toType)
       val methods = delegateMethods(Fa, overridableMembersOf(Fa), NoSymbol) {
-        case method @ Method(m, _, _, rt, _) =>
-          val argLists = method.actualArgs
-          if (rt.typeSymbol == a) {
-            val step = TermName(c.freshName("step"))
-            val current = TermName(c.freshName("current"))
-            val body = q"""{
-              @_root_.scala.annotation.tailrec def $step($current: $a): $b =
-                $f($current).$m[..${method.typeArgs}](...$argLists) match {
-                  case _root_.scala.Left(next) => $step(next)
-                  case _root_.scala.Right(target) => target
-                }
+        case method if method.returnType.typeSymbol == a =>
+          val step = TermName(c.freshName("step"))
+          val current = TermName(c.freshName("current"))
+          val body = q"""{
+            @_root_.scala.annotation.tailrec def $step($current: $a): $b =
+              ${method.delegate(q"$f($current)")} match {
+                case _root_.scala.Left(next) => $step(next)
+                case _root_.scala.Right(target) => target
+              }
 
-              $step($x)
-            }"""
+            $step($x)
+          }"""
 
-            method.copy(rt = appliedType(b, rt.typeArgs), body = body)
-          } else {
-            val body = q"$f($x).$m[..${method.typeArgs}](...$argLists)"
-            method.copy(body = body)
-          }
+          method.copy(returnType = b.asType.toType, body = body)
+        case method if method.occursInSignature(a) =>
+          abort(s"Type parameter $a can only appear as a top level return type in method ${method.name}")
+        case method =>
+          method.copy(body = method.delegate(q"$f($x)"))
       }
 
-      implement(appliedType(algebra, b.asType.toTypeConstructor), methods)
+      implement(algebra)(b)(methods)
     }
 
   // def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D]
@@ -323,19 +404,32 @@ class DeriveMacros(val c: blackbox.Context) {
       val Fab = singleType(NoPrefix, fab)
       val members = overridableMembersOf(Fab)
       val types = delegateAbstractTypes(Fab, members, Fab)
-      val methods = delegateMethods(Fab, members, fab.asTerm) {
-        case method @ Method(m, _, _, rt, _) if rt.typeSymbol == b || method.paramsContainTopLevel(a) =>
-          val paramLists = method.paramLists(tpe => if (tpe.typeSymbol == a) appliedType(c, tpe.typeArgs) else tpe)
-          val argLists = method.argLists((pn, pt) => if (pt.typeSymbol == a) q"$f($pn)" else Ident(pn))
-          val returnType = if (rt.typeSymbol == b) appliedType(d, rt.typeArgs) else rt
-          val delegate = q"$fab.$m[..${method.typeArgs}](...$argLists)"
-          val body = if (rt.typeSymbol == b) q"$g($delegate)" else delegate
-          method.copy(pss = paramLists, rt = returnType, body = body)
+      val methods = delegateMethods(Fab, members, fab) {
+        case method if method.occursInSignature(a) || method.occursInSignature(b) =>
+          method.transform(fab, a -> c, b -> d) {
+            case (pn, pt) if occursIn(pt)(a) && occursIn(pt)(b) =>
+              val F = summon[Profunctor[Any]](polyType(b :: a :: Nil, pt))
+              q"$F.dimap[$d, $c, $b, $a]($pn)($g)($f)"
+            case (pn, pt) if occursIn(pt)(a) =>
+              val F = summon[Functor[Any]](polyType(a :: Nil, pt))
+              q"$F.map[$c, $a]($pn)($f)"
+            case (pn, pt) if occursIn(pt)(b) =>
+              val F = summon[Contravariant[Any]](polyType(b :: Nil, pt))
+              q"$F.contramap[$d, $b]($pn)($g)"
+          } {
+            case delegate if method.occursInReturn(a) && method.occursInReturn(b) =>
+              val F = summon[Profunctor[Any]](polyType(a :: b :: Nil, method.returnType))
+              q"$F.dimap[$a, $b, $c, $d]($delegate)($f)($g)"
+            case delegate if method.occursInReturn(a) =>
+              val F = summon[Contravariant[Any]](polyType(a :: Nil, method.returnType))
+              q"$F.contramap[$a, $c]($delegate)($f)"
+            case delegate if method.occursInReturn(b) =>
+              val F = summon[Functor[Any]](polyType(b :: Nil, method.returnType))
+              q"$F.map[$b, $d]($delegate)($g)"
+          }
       }
 
-      val C = c.asType.toTypeConstructor
-      val D = d.asType.toTypeConstructor
-      implement(appliedType(algebra, C, D), types ++ methods)
+      implement(algebra)(c, d)(types ++ methods)
     }
 
   // def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D]
@@ -344,65 +438,60 @@ class DeriveMacros(val c: blackbox.Context) {
       val Fab = singleType(NoPrefix, fab)
       val members = overridableMembersOf(Fab)
       val types = delegateAbstractTypes(Fab, members, Fab)
-      val methods = delegateMethods(Fab, members, fab.asTerm) {
-        case method @ Method(m, _, _, rt, _) if rt.typeSymbol == a || rt.typeSymbol == b =>
-          val delegate = q"$fab.$m[..${method.typeArgs}](...${method.actualArgs})"
-          val (returnType, func) = if (rt.typeSymbol == a) (c, f) else (d, g)
-          method.copy(rt = appliedType(returnType, rt.typeArgs), body = q"$func($delegate)")
+      val methods = delegateMethods(Fab, members, fab) {
+        case method if method.occursInSignature(a) || method.occursInSignature(b) =>
+          method.transform(fab, a -> c, b -> d) {
+            case (_, pt) if occursIn(pt)(a) && occursIn(pt)(b) =>
+              abort(s"Both type parameters $a and $b appear in contravariant position in method ${method.name}")
+            case (pn, pt) if occursIn(pt)(a) =>
+              val F = summon[Contravariant[Any]](polyType(a :: Nil, pt))
+              q"$F.contramap[$c, $a]($pn)($f)"
+            case (pn, pt) if occursIn(pt)(b) =>
+              val F = summon[Contravariant[Any]](polyType(b :: Nil, pt))
+              q"$F.contramap[$d, $b]($pn)($g)"
+          } {
+            case delegate if method.occursInReturn(a) && method.occursInReturn(b) =>
+              val F = summon[Bifunctor[Any]](polyType(a :: b :: Nil, method.returnType))
+              q"$F.bimap[$a, $b, $c, $d]($delegate)($f, $g)"
+            case delegate if method.occursInReturn(a) =>
+              val F = summon[Functor[Any]](polyType(a :: Nil, method.returnType))
+              q"$F.map[$a, $c]($delegate)($f)"
+            case delegate if method.occursInReturn(b) =>
+              val F = summon[Functor[Any]](polyType(b :: Nil, method.returnType))
+              q"$F.map[$b, $d]($delegate)($g)"
+          }
       }
 
-      val C = c.asType.toTypeConstructor
-      val D = d.asType.toTypeConstructor
-      implement(appliedType(algebra, C, D), types ++ methods)
+      implement(algebra)(c, d)(types ++ methods)
     }
 
-  def functor[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[Functor[Any]], F)(mapK(F).copy(_1 = "map"))
-  }
+  def functor[F[_]](implicit tag: WeakTypeTag[F[Any]]): Tree =
+    instantiate[Functor[F]](tag)(map)
 
-  def contravariant[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[Contravariant[Any]], F)(contramapK(F).copy(_1 = "contramap"))
-  }
+  def contravariant[F[_]](implicit tag: WeakTypeTag[F[Any]]): Tree =
+    instantiate[Contravariant[F]](tag)(contramap)
 
-  def invariant[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[Invariant[Any]], F)(imapK(F).copy(_1 = "imap"))
-  }
+  def invariant[F[_]](implicit tag: WeakTypeTag[F[Any]]): Tree =
+    instantiate[Invariant[F]](tag)(imap)
 
-  def profunctor[F[_, _]](implicit tag: c.WeakTypeTag[F[Any, Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[Profunctor[F]], F)(dimap(F))
-  }
+  def profunctor[F[_, _]](implicit tag: WeakTypeTag[F[Any, Any]]): Tree =
+    instantiate[Profunctor[F]](tag)(dimap)
 
-  def bifunctor[F[_, _]](implicit tag: c.WeakTypeTag[F[Any, Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[Bifunctor[F]], F)(bimap(F))
-  }
+  def bifunctor[F[_, _]](implicit tag: WeakTypeTag[F[Any, Any]]): Tree =
+    instantiate[Bifunctor[F]](tag)(bimap)
 
-  def flatMap[F[_]](implicit tag: c.WeakTypeTag[F[Any]]): c.Tree = {
-    val F = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[FlatMap[Any]], F)(mapK(F).copy(_1 = "map"), flatMapK(F).copy(_1 = "flatMap"), tailRecM(F))
-  }
+  def flatMap[F[_]](implicit tag: WeakTypeTag[F[Any]]): Tree =
+    instantiate[FlatMap[F]](tag)(map, flatMap_, tailRecM)
 
-  def functorK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
-    val Alg = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[FunctorK[Any]], Alg)(mapK(Alg))
-  }
+  def functorK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
+    instantiate[FunctorK[Alg]](tag)(mapK)
 
-  def invariantK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
-    val Alg = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[InvariantK[Any]], Alg)(imapK(Alg))
-  }
+  def invariantK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
+    instantiate[InvariantK[Alg]](tag)(imapK)
 
-  def semigroupalK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
-    val Alg = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[SemigroupalK[Any]], Alg)(productK(Alg))
-  }
+  def semigroupalK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
+    instantiate[SemigroupalK[Alg]](tag)(productK)
 
-  def applyK[Alg[_[_]]](implicit tag: c.WeakTypeTag[Alg[Any]]): c.Tree = {
-    val Alg = normalizedTypeConstructor(tag)
-    instantiate(symbolOf[ApplyK[Any]], Alg)(mapK(Alg), productK(Alg))
-  }
+  def applyK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
+    instantiate[ApplyK[Alg]](tag)(mapK, productK)
 }

--- a/tests/src/test/scala/cats/tagless/tests/CatsDataInstancesTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/CatsDataInstancesTests.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+
+import cats.Eval
+import cats.data._
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.tagless.IdK
+import cats.tagless.laws.discipline.SemigroupalKTests.IsomorphismsK
+import cats.tagless.laws.discipline.{ApplyKTests, FunctorKTests}
+
+import scala.util.Try
+
+class CatsDataInstancesTests extends CatsTaglessTestSuite {
+  implicit def idKisomorphismK[A]: IsomorphismsK[IdK[A]#λ] = IsomorphismsK.invariantK[IdK[A]#λ]
+
+  checkAll("FunctorK[Nested[?[_], Eval, Int]]", FunctorKTests[Nested[?[_], Eval, Int]].functorK[Try, Option, List, Int])
+  checkAll("FunctorK[OneAnd[?[_], Boolean]]", FunctorKTests[OneAnd[?[_], Boolean]].functorK[Try, Option, List, Int])
+  checkAll("FunctorK[Tuple2K[Eval, ?[_], Int]]", FunctorKTests[Tuple2K[Eval, ?[_], Int]].functorK[Try, Option, List, Int])
+  checkAll("ApplyK[IdK[Int]#λ]", ApplyKTests[IdK[Int]#λ].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[EitherK[Eval, ?[_], Int]]", ApplyKTests[EitherK[Eval, ?[_], Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[EitherT[?[_], String, Int]]", ApplyKTests[EitherT[?[_], String, Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[Func[?[_], String, Int]]", ApplyKTests[Func[?[_], String, Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[IdT[?[_], Int]]", ApplyKTests[IdT[?[_], Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[IorT[?[_], String, Int]]", ApplyKTests[IorT[?[_], String, Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[Kleisli[?[_], String, Int]]", ApplyKTests[Kleisli[?[_], String, Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[OneAnd[?[_], Int]]", ApplyKTests[OneAnd[?[_], Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[OptionT[?[_], Int]]", ApplyKTests[OptionT[?[_], Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[Tuple2K[Set, ?[_], Int]]", ApplyKTests[Tuple2K[Set, ?[_], Int]].applyK[Try, Option, List, Int])
+  checkAll("ApplyK[WriterT[?[_], String, Int]]", ApplyKTests[WriterT[?[_], String, Int]].applyK[Try, Option, List, Int])
+}

--- a/tests/src/test/scala/cats/tagless/tests/CatsTaglessTestSuite.scala
+++ b/tests/src/test/scala/cats/tagless/tests/CatsTaglessTestSuite.scala
@@ -15,52 +15,112 @@
  */
 
 package cats.tagless.tests
-import cats.tests.CatsSuite
+
+import cats.Eq
 import cats.arrow.FunctionK
-import cats.instances.AllInstances
-import cats.kernel.Eq
+import cats.data._
 import cats.laws.discipline.ExhaustiveCheck
-import cats.laws.discipline.ExhaustiveCheck.instance
+import cats.tagless.instances.AllInstances
+import cats.tagless.laws.discipline.SemigroupalKTests.IsomorphismsK
 import cats.tagless.syntax.AllSyntax
+import cats.tagless.{InvariantK, Tuple3K}
+import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Gen}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class CatsTaglessTestSuite extends CatsSuite with TestInstances with AllInstances with AllSyntax
 
+object TestInstances extends TestInstances
 
 trait TestInstances {
-  implicit val catsDataArbitraryOptionList: Arbitrary[FunctionK[Option, List]] = Arbitrary(Gen.const(λ[FunctionK[Option, List]](_.toList)))
-  implicit val catsDataArbitraryListOption: Arbitrary[FunctionK[List, Option]] = Arbitrary(Gen.const(λ[FunctionK[List, Option]](_.headOption)))
-  implicit val catsDataArbitraryTryOption: Arbitrary[FunctionK[Try, Option]] = Arbitrary(Gen.const(λ[FunctionK[Try, Option]](_.toOption)))
-  implicit val catsDataArbitraryOptionTry: Arbitrary[FunctionK[Option, Try]] = Arbitrary(Gen.const(λ[FunctionK[Option, Try]](o => Try(o.get))))
-  implicit val catsDataArbitraryListVector: Arbitrary[FunctionK[List, Vector]] = Arbitrary(Gen.const(λ[FunctionK[List, Vector]](_.toVector)))
-  implicit val catsDataArbitraryVectorList: Arbitrary[FunctionK[Vector, List]] = Arbitrary(Gen.const(λ[FunctionK[Vector, List]](_.toList)))
 
-  implicit val eqThrow: Eq[Throwable] = Eq.allEqual
+  implicit val catsDataArbitraryOptionList: Arbitrary[FunctionK[Option, List]] =
+    Arbitrary(Gen.const(λ[FunctionK[Option, List]](_.toList)))
 
-  implicit def exhaustiveCheckForTry[A](implicit A: ExhaustiveCheck[A]): ExhaustiveCheck[Try[A]] =
-    instance(Stream.cons(Failure(new RuntimeException("some exception")), A.allValues.map(Success(_))))
+  implicit val catsDataArbitraryListOption: Arbitrary[FunctionK[List, Option]] =
+    Arbitrary(Gen.const(λ[FunctionK[List, Option]](_.headOption)))
 
-  implicit def exhaustiveCheckForList[A](implicit A: ExhaustiveCheck[A]): ExhaustiveCheck[List[A]] =
-    instance(Stream.cons(Nil, A.allValues.map(List(_))))
+  implicit val catsDataArbitraryTryOption: Arbitrary[FunctionK[Try, Option]] =
+    Arbitrary(Gen.const(λ[FunctionK[Try, Option]](_.toOption)))
 
-  implicit def exhaustiveCheckForString: ExhaustiveCheck[String] = new ExhaustiveCheck[String] {
-    override def allValues: Stream[String] = List("", "fasdf23", "dv23[09;ksf", "dfa, ", "dcv2,asdk234;riosd;fkj;").toStream
-  }
+  implicit val catsDataArbitraryOptionTry: Arbitrary[FunctionK[Option, Try]] =
+    Arbitrary(Gen.const(λ[FunctionK[Option, Try]](o => Try(o.get))))
 
-  implicit def exhaustiveCheckForFloat: ExhaustiveCheck[Float] = new ExhaustiveCheck[Float] {
-    override def allValues: Stream[Float] = List(-1f, 32f, 0f, 322342342523567.23423f, 100f).toStream
-  }
+  implicit val catsDataArbitraryListVector: Arbitrary[FunctionK[List, Vector]] =
+    Arbitrary(Gen.const(λ[FunctionK[List, Vector]](_.toVector)))
 
-  implicit def exhaustiveCheckForInt: ExhaustiveCheck[Int] = new ExhaustiveCheck[Int] {
-    override def allValues: Stream[Int] = List(-1, 32, 0, 322232342, 100).toStream
-  }
+  implicit val catsDataArbitraryVectorList: Arbitrary[FunctionK[Vector, List]] =
+    Arbitrary(Gen.const(λ[FunctionK[Vector, List]](_.toList)))
 
-  implicit def exhaustiveCheckForLong: ExhaustiveCheck[Long] = new ExhaustiveCheck[Long] {
-    override def allValues: Stream[Long] = List(-1L, 32L, 0L, 23423322232342L, 100L, -234234324235L).toStream
-  }
+  implicit val catsTaglessLawsEqForThrowable: Eq[Throwable] = Eq.allEqual
 
+  implicit def catsTaglessLawsExhaustiveCheckForArbitrary[A: Arbitrary]: ExhaustiveCheck[A] =
+    ExhaustiveCheck.instance(Gen.resize(30, Arbitrary.arbitrary[Stream[A]]).sample.get)
+
+  implicit def catsTaglessLawsEqForFunc[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Func[F, A, B]] =
+    Eq.by(_.run)
+
+  implicit def catsTaglessLawsEqForKleisli[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
+    Eq.by(_.run)
+
+  //------------------------------------------------------------------
+  // The instances below are needed due to type inference limitations:
+  //------------------------------------------------------------------
+
+  implicit def catsTaglessLawsIsomorphismsK110[Alg[_[_], _[_], _], F[_], A](
+    implicit ev: InvariantK[Alg[F, ?[_], A]]
+  ): IsomorphismsK[Alg[F, ?[_], A]] = IsomorphismsK.invariantK[Alg[F, ?[_], A]]
+
+  implicit def catsTaglessLawsIsomorphismsK100[Alg[_[_], _, _], A, B](
+    implicit ev: InvariantK[Alg[?[_], A, B]]
+  ): IsomorphismsK[Alg[?[_], A, B]] = IsomorphismsK.invariantK[Alg[?[_], A, B]]
+
+  implicit def catsTaglessLawsIsomorphismsK10[Alg[_[_], _], A](
+    implicit ev: InvariantK[Alg[?[_], A]]
+  ): IsomorphismsK[Alg[?[_], A]] = IsomorphismsK.invariantK[Alg[?[_], A]]
+
+  implicit def catsTaglessLawsEqForTuple2K[F[_], G[_], A](
+    implicit ev: Eq[(F[A], G[A])]
+  ): Eq[Tuple2K[F, G, A]] = Eq.by(t2k => (t2k.first, t2k.second))
+
+  implicit def catsTaglessLawsEqForEitherKTuple3K[F[_], G[_], H[_], I[_], A](
+    implicit ev: Eq[Either[F[A], (G[A], H[A], I[A])]]
+  ): Eq[EitherK[F, Tuple3K[G, H, I]#λ, A]] = Eq.by(_.run)
+
+  implicit def catsTaglessLawsEqForEitherTTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[(F[Either[A, B]], G[Either[A, B]], H[Either[A, B]])]
+  ): Eq[EitherT[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.value)
+
+  implicit def catsTaglessLawsEqForFuncTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[A => (F[B], G[B], H[B])]
+  ): Eq[Func[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.run)
+
+  implicit def catsTaglessLawsEqForIdTTuple3K[F[_], G[_], H[_], A](
+    implicit ev: Eq[(F[A], G[A], H[A])]
+  ): Eq[IdT[Tuple3K[F, G, H]#λ, A]] = Eq.by(_.value)
+
+  implicit def catsTaglessLawsEqForIorTTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[(F[Ior[A, B]], G[Ior[A, B]], H[Ior[A, B]])]
+  ): Eq[IorT[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.value)
+
+  implicit def catsTaglessLawsEqForKleisliTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[A => (F[B], G[B], H[B])]
+  ): Eq[Kleisli[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.run)
+
+  implicit def catsTaglessLawsEqForOneAndTuple3K[F[_], G[_], H[_], A](
+    implicit ev: Eq[(A, (F[A], G[A], H[A]))]
+  ): Eq[OneAnd[Tuple3K[F, G, H]#λ, A]] = Eq.by(x => (x.head, x.tail))
+
+  implicit def catsTaglessLawsEqForOptionTTuple3K[F[_], G[_], H[_], A](
+    implicit ev: Eq[(F[Option[A]], G[Option[A]], H[Option[A]])]
+  ): Eq[OptionT[Tuple3K[F, G, H]#λ, A]] = Eq.by(_.value)
+
+  implicit def catsTaglessLawsEqForTuple2KTuple3K[F[_], G[_], H[_], I[_], A](
+    implicit ev: Eq[(F[A], (G[A], H[A], I[A]))]
+  ): Eq[Tuple2K[F, Tuple3K[G, H, I]#λ, A]] = Eq.by(t2k => (t2k.first, t2k.second))
+
+  implicit def catsTaglessLawsEqForWriterTTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[(F[(A, B)], G[(A, B)], H[(A, B)])]
+  ): Eq[WriterT[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.run)
 }
-
-object TestInstances extends TestInstances

--- a/tests/src/test/scala/cats/tagless/tests/TestAlgebras.scala
+++ b/tests/src/test/scala/cats/tagless/tests/TestAlgebras.scala
@@ -17,72 +17,77 @@
 package cats.tagless
 package tests
 
-import cats.{Eval, Monoid, ~>}
-import cats.data.Tuple2K
-import cats.kernel.Eq
-import org.scalacheck.{Arbitrary, Cogen}
-import cats.data.State
-
-import scala.util.Try
-import cats.laws.discipline.eq._
+import cats.{Eq, Eval, Monoid, ~>}
+import cats.data.{EitherT, Kleisli, State, Tuple2K}
 import cats.implicits._
 import cats.laws.discipline.ExhaustiveCheck
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.tagless.instances.all._
+import org.scalacheck.{Arbitrary, Cogen}
+
+import scala.util.Try
 
 @finalAlg @autoFunctorK @autoSemigroupalK @autoProductNK
 trait SafeAlg[F[_]] {
-  def parseInt(i: String): F[Int]
+  def parseInt(str: String): F[Int]
   def divide(dividend: Float, divisor: Float): F[Float]
 }
 
 object SafeAlg  {
   import TestInstances._
 
-  implicit def eqForSafeAlg[F[_]](implicit eqFInt: Eq[F[Int]], eqFFloat: Eq[F[Float]]): Eq[SafeAlg[F]] =
-    Eq.by[SafeAlg[F], (String => F[Int], (((Float, Float)) => F[Float]))] { p => (
-      (s: String) => p.parseInt(s),
-      (pair: (Float, Float)) => p.divide(pair._1, pair._2))
-    }
+  implicit def eqForSafeAlg[F[_]](implicit eqFi: Eq[F[Int]], eqFf: Eq[F[Float]]): Eq[SafeAlg[F]] =
+    Eq.by(algebra => (algebra.parseInt _, algebra.divide _))
 
-  implicit def arbitrarySafeAlg[F[_]](implicit cS: Cogen[String],
-                                       gF: Cogen[Float],
-                                       FI: Arbitrary[F[Int]],
-                                       FB: Arbitrary[F[Float]]): Arbitrary[SafeAlg[F]] =
-    Arbitrary {
-      for {
-        f1 <- Arbitrary.arbitrary[String => F[Int]]
-        f2 <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
-      } yield new SafeAlg[F] {
-        def parseInt(i: String): F[Int] = f1(i)
-        def divide(dividend: Float, divisor: Float): F[Float] = f2(dividend, divisor)
-      }
+  implicit def arbitrarySafeAlg[F[_]](
+    implicit arbFi: Arbitrary[F[Int]], arbFs: Arbitrary[F[Float]]
+  ): Arbitrary[SafeAlg[F]] = Arbitrary {
+    for {
+      pInt <- Arbitrary.arbitrary[String => F[Int]]
+      div <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
+    } yield new SafeAlg[F] {
+      def parseInt(str: String) = pInt(str)
+      def divide(dividend: Float, divisor: Float) = div(dividend, divisor)
     }
+  }
 }
-
 
 @finalAlg @autoInvariantK
 trait SafeInvAlg[F[_]] {
-  def parseInt(i: F[String]): F[Int]
+  def parseInt(fs: F[String]): F[Int]
+  def doubleParser(precision: Int): Kleisli[F, String, Double]
+  def parseIntOrError(fs: EitherT[F, String, String]): F[Int]
 }
 
 object SafeInvAlg {
+  import TestInstances._
 
-  implicit def eqForSafeInvAlg[F[_]](implicit eqFInt: Eq[F[Int]],
-                                     exchck: ExhaustiveCheck[F[String]]): Eq[SafeInvAlg[F]] =
-    Eq.by[SafeInvAlg[F], F[String] => F[Int]] { p =>
-      (s: F[String]) => p.parseInt(s)
+  implicit def eqForSafeInvAlg[F[_]](
+    implicit eqFi: Eq[F[Int]],
+    eqFd: Eq[F[Double]],
+    exFs: ExhaustiveCheck[F[String]],
+    exEfs: ExhaustiveCheck[EitherT[F, String, String]]
+  ): Eq[SafeInvAlg[F]] = Eq.by {
+    algebra => (algebra.parseInt _, algebra.doubleParser _, algebra.parseIntOrError _)
+  }
+
+  implicit def arbitrarySafeInvAlg[F[_]](
+    implicit coF: Cogen[F[String]],
+    coEfs: Cogen[EitherT[F, String, String]],
+    arbFi: Arbitrary[F[Int]],
+    arbFd: Arbitrary[F[Double]]
+  ): Arbitrary[SafeInvAlg[F]] = Arbitrary {
+    for {
+      pInt <- Arbitrary.arbitrary[F[String] => F[Int]]
+      pDouble <- Arbitrary.arbitrary[Int => Kleisli[F, String, Double]]
+      pError <- Arbitrary.arbitrary[EitherT[F, String, String] => F[Int]]
+    } yield new SafeInvAlg[F] {
+      def parseInt(fs: F[String]) = pInt(fs)
+      def doubleParser(precision: Int) = pDouble(precision)
+      def parseIntOrError(fs: EitherT[F, String, String]) = pError(fs)
     }
-
-  implicit def arbitrarySafeInvAlg[F[_]](implicit
-                                       gF: Cogen[F[String]],
-                                       FI: Arbitrary[F[Int]]): Arbitrary[SafeInvAlg[F]] =
-    Arbitrary {
-      for {
-        f <- Arbitrary.arbitrary[F[String] => F[Int]]
-      } yield new SafeInvAlg[F] {
-        def parseInt(i: F[String]): F[Int] = f(i)
-
-      }
-    }
+  }
 }
 
 trait KVStore[F[_]] {
@@ -92,10 +97,9 @@ trait KVStore[F[_]] {
 
 object KVStore {
   implicit val applyKForKVStore: ApplyK[KVStore] = new ApplyK[KVStore] {
-    def mapK[F[_], G[_]](algf: KVStore[F])(f: ~>[F, G]): KVStore[G] = new KVStore[G] {
-      def get(key: String): G[Option[String]] = f(algf.get(key))
-
-      def put(key: String, a: String): G[Unit] = f(algf.put(key, a))
+    def mapK[F[_], G[_]](af: KVStore[F])(f: ~>[F, G]): KVStore[G] = new KVStore[G] {
+      def get(key: String): G[Option[String]] = f(af.get(key))
+      def put(key: String, a: String): G[Unit] = f(af.put(key, a))
     }
 
     def productK[F[_], G[_]](af: KVStore[F], ag: KVStore[G]): KVStore[Tuple2K[F, G, ?]] =
@@ -120,27 +124,25 @@ object KVStoreInfo {
   }
 }
 
-
-
 object Interpreters {
 
   implicit object tryInterpreter extends SafeAlg[Try] {
-    def parseInt(s: String) = Try(s.toInt)
+    def parseInt(str: String): Try[Int] = Try(str.toInt)
     def divide(dividend: Float, divisor: Float): Try[Float] = Try(dividend / divisor)
   }
 
   implicit object lazyInterpreter extends SafeAlg[Eval] {
-    def parseInt(s: String): Eval[Int] = Eval.later(s.toInt)
+    def parseInt(str: String): Eval[Int] = Eval.later(str.toInt)
     def divide(dividend: Float, divisor: Float): Eval[Float] = Eval.later(dividend / divisor)
   }
 
   object KVStoreInterpreter extends KVStore[State[StateInfo, ?]] {
     def get(key: String): State[StateInfo, Option[String]] =
-      State.modify[StateInfo](s => s.copy(searches = s.searches.updated(key, s.searches.get(key).getOrElse(0) + 1)))
+      State.modify[StateInfo](s => s.copy(searches = s.searches.updated(key, s.searches.getOrElse(key, 0) + 1)))
         .as(Option(key + "!"))
 
     def put(key: String, a: String): State[StateInfo, Unit] =
-      State.modify[StateInfo](s => s.copy(inserts = s.inserts.updated(key, s.inserts.get(key).getOrElse(0) + 1)))
+      State.modify[StateInfo](s => s.copy(inserts = s.inserts.updated(key, s.inserts.getOrElse(key, 0) + 1)))
   }
 
   case class StateInfo(searches: Map[String, Int], inserts: Map[String, Int])
@@ -148,5 +150,4 @@ object Interpreters {
   object StateInfo {
     def empty = StateInfo(Map.empty, Map.empty)
   }
-
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoApplyKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoApplyKTests.scala
@@ -17,57 +17,57 @@
 package cats.tagless
 package tests
 
-
-import cats.kernel.Eq
+import cats.Eq
+import cats.data.EitherT
+import cats.instances.all._
 import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.tagless.instances.all._
 import cats.tagless.laws.discipline.ApplyKTests
 import cats.tagless.tests.autoApplyKTests.AutoApplyKTestAlg
+import org.scalacheck.Arbitrary
 
-import util.Try
+import scala.util.Try
 
 class autoApplyKTests extends CatsTaglessTestSuite {
-
-  implicit def eqT32 = AutoApplyKTestAlg.eqForAutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ] //have to help scalac here
-
-  checkAll("AutoApplyKTestAlg[Option]", ApplyKTests[AutoApplyKTestAlg].applyK[Try, Option, List, Int])
-  checkAll("ApplyK[ParseAlg]", SerializableTests.serializable(ApplyK[AutoApplyKTestAlg]))
-
+  // Type inference limitation.
+  implicit val eqTuple3K = AutoApplyKTestAlg.eqForAutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ]
+  checkAll("ApplyK[AutoApplyKTestAlg]", ApplyKTests[AutoApplyKTestAlg].applyK[Try, Option, List, Int])
+  checkAll("ApplyK is Serializable", SerializableTests.serializable(ApplyK[AutoApplyKTestAlg]))
 }
 
 object autoApplyKTests {
-  import org.scalacheck.{Arbitrary, Cogen}
-
-  import cats.laws.discipline.eq._
-  import cats.implicits._
 
   @autoApplyK(autoDerivation = false)
   trait AutoApplyKTestAlg[F[_]] {
-    def parseInt(i: String): F[Int]
+    def parseInt(str: String): F[Int]
+    def parseDouble(str: String): EitherT[F, String, Double]
     def divide(dividend: Float, divisor: Float): F[Float]
   }
 
   object AutoApplyKTestAlg {
     import TestInstances._
 
-    implicit def eqForAutoApplyKTestAlg[F[_]](implicit eqFInt: Eq[F[Int]], eqFFloat: Eq[F[Float]]): Eq[AutoApplyKTestAlg[F]] =
-      Eq.by[AutoApplyKTestAlg[F], (String => F[Int], (((Float, Float)) => F[Float]))] { p => (
-        (s: String) => p.parseInt(s),
-        (pair: (Float, Float)) => p.divide(pair._1, pair._2))
-      }
+    implicit def eqForAutoApplyKTestAlg[F[_]](
+      implicit eqFi: Eq[F[Int]], eqFf: Eq[F[Float]], eqEfd: Eq[EitherT[F, String, Double]]
+    ): Eq[AutoApplyKTestAlg[F]] = Eq.by {
+      algebra => (algebra.parseInt _, algebra.parseDouble _, algebra.divide _)
+    }
 
-    implicit def arbitraryAutoApplyKTestAlg[F[_]](implicit cS: Cogen[String],
-                                        gF: Cogen[Float],
-                                        FI: Arbitrary[F[Int]],
-                                        FB: Arbitrary[F[Float]]): Arbitrary[AutoApplyKTestAlg[F]] =
-      Arbitrary {
-        for {
-          f1 <- Arbitrary.arbitrary[String => F[Int]]
-          f2 <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
-        } yield new AutoApplyKTestAlg[F] {
-          def parseInt(i: String): F[Int] = f1(i)
-          def divide(dividend: Float, divisor: Float): F[Float] = f2(dividend, divisor)
-        }
+    implicit def arbitraryAutoApplyKTestAlg[F[_]](
+      implicit arbFi: Arbitrary[F[Int]], arbFf: Arbitrary[F[Float]], arbEfd: Arbitrary[EitherT[F, String, Double]]
+    ): Arbitrary[AutoApplyKTestAlg[F]] = Arbitrary {
+      for {
+        pInt <- Arbitrary.arbitrary[String => F[Int]]
+        pDouble <- Arbitrary.arbitrary[String => EitherT[F, String, Double]]
+        div <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
+      } yield new AutoApplyKTestAlg[F] {
+        def parseInt(str: String) = pInt(str)
+        def parseDouble(str: String) = pDouble(str)
+        def divide(dividend: Float, divisor: Float) = div(dividend, divisor)
       }
+    }
   }
 
   @autoApplyK

--- a/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoContravariantTest.scala
@@ -17,27 +17,25 @@
 package cats.tagless
 package tests
 
-
+import cats.{Contravariant, Eq}
+import cats.instances.all._
 import cats.laws.discipline.{ContravariantTests, ExhaustiveCheck, SerializableTests}
-import autoContravariantTest._
-import cats.kernel.Eq
-import org.scalacheck.{Arbitrary, Cogen}
 import cats.laws.discipline.eq._
-import cats.Contravariant
+import cats.tagless.tests.autoContravariantTest._
+import org.scalacheck.{Arbitrary, Cogen}
 
 class autoContravariantTests extends CatsTaglessTestSuite {
-
-  checkAll("SimpleAlg[Option]", ContravariantTests[SimpleAlg].contravariant[Float, String, Int])
-  checkAll("Invariant[SimpleAlg]", SerializableTests.serializable(Contravariant[SimpleAlg]))
+  checkAll("Contravariant[SimpleAlg]", ContravariantTests[SimpleAlg].contravariant[Float, String, Int])
+  checkAll("Contravariant is Serializable", SerializableTests.serializable(Contravariant[SimpleAlg]))
 
   test("non effect method correctly delegated") {
-    val doubleAlg = AlgWithNonEffectMethodFloat.contramap[String](_.toFloat)
+    val doubleAlg: AlgWithNonEffectMethod[String] = AlgWithNonEffectMethodFloat.contramap[String](_.toFloat)
     doubleAlg.foo2("big") should be("gib")
     doubleAlg.foo3("3") should be("3")
   }
 
   test("extra type param correctly handled") {
-    val doubleAlg = AlgWithExtraTypeParamFloat.contramap[String](_.toFloat)
+    val doubleAlg: AlgWithExtraTypeParam[String, String] = AlgWithExtraTypeParamFloat.contramap[String](_.toFloat)
     doubleAlg.foo("big", "3") should be(6)
   }
 
@@ -49,14 +47,14 @@ class autoContravariantTests extends CatsTaglessTestSuite {
     intAlg.contramap[String](_.toInt).plusOne("3") should be(4)
     intAlg.contramap[String](_.toInt).minusOne(2) should be(1)
   }
-
 }
 
 object autoContravariantTest {
 
   @autoContravariant
   trait SimpleAlg[T] {
-    def foo(a: T): String
+    def foo(t: T): String
+    def bar(opt: Option[T]): String
   }
 
   @autoContravariant
@@ -106,19 +104,17 @@ object autoContravariantTest {
     def foo(a: String, b: Float): Int = (a.length.toFloat + b).toInt
   }
 
-
-  import cats.instances.string._
   implicit def eqForSimpleAlg[T: ExhaustiveCheck: Eq]: Eq[SimpleAlg[T]] =
-    Eq.by[SimpleAlg[T], T => String] { p =>
-      (s: T) => p.foo(s)
-    }
+    Eq.by(algebra => (algebra.foo _, algebra.bar _))
 
   implicit def arbitrarySimpleAlg[T: Cogen]: Arbitrary[SimpleAlg[T]] =
     Arbitrary {
       for {
         f <- Arbitrary.arbitrary[T => String]
+        g <- Arbitrary.arbitrary[Option[T] => String]
       } yield new SimpleAlg[T] {
-        def foo(i: T): String = f(i)
+        def foo(t: T) = f(t)
+        def bar(opt: Option[T]) = g(opt)
       }
     }
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFlatMapTests.scala
@@ -16,22 +16,21 @@
 
 package cats.tagless.tests
 
-import cats.FlatMap
-import cats.kernel.Eq
-import cats.kernel.instances.string._
-import cats.kernel.instances.tuple._
-import cats.laws.discipline.eq._
+import cats.{Eq, FlatMap}
+import cats.instances.all._
 import cats.laws.discipline.{FlatMapTests, SerializableTests}
+import cats.laws.discipline.eq._
 import cats.tagless.autoFlatMap
-import cats.tagless.tests.autoFlatMapTests._
 import org.scalacheck.{Arbitrary, Cogen}
+
 class autoFlatMapTests extends CatsTaglessTestSuite {
+  import autoFlatMapTests._
 
   checkAll("FlatMap[TestAlgebra]", FlatMapTests[TestAlgebra].flatMap[Float, String, Int])
   checkAll("serializable FlatMap[TestAlgebra]", SerializableTests.serializable(FlatMap[TestAlgebra]))
 
   test("extra type param correctly handled") {
-    val doubleAlg = AlgWithExtraTypeParamFloat.map(_.toDouble)
+    val doubleAlg: AlgWithExtraTypeParam[String, Double] = AlgWithExtraTypeParamFloat.map(_.toDouble)
     doubleAlg.foo("big") should be(3d)
   }
 }
@@ -42,13 +41,9 @@ object autoFlatMapTests {
   @autoFlatMap
   trait TestAlgebra[T] {
     def abstractEffect(a: String): T
-
     def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
-
     def abstractOther(a: String): String
-
     def concreteOther(a: String): String = a + " concreteOther"
-
     def withoutParams: T
   }
 
@@ -72,14 +67,15 @@ object autoFlatMapTests {
     def generic[A](as: A*): T
   }
 
-  implicit def eqForTestAlgebra[T](implicit eqT: Eq[T]): Eq[TestAlgebra[T]] =
-    Eq.by { p =>
-      (p.abstractEffect: String => T) ->
-        (p.concreteEffect: String => T) ->
-        (p.abstractOther: String => String) ->
-        (p.concreteOther: String => String) ->
-        p.withoutParams
-    }
+  implicit def eqForTestAlgebra[T: Eq]: Eq[TestAlgebra[T]] = Eq.by { algebra =>
+    (
+      algebra.abstractEffect _,
+      algebra.concreteEffect _,
+      algebra.abstractOther _,
+      algebra.concreteOther _,
+      algebra.withoutParams
+    )
+  }
 
   implicit def arbitraryTestAlgebra[T: Arbitrary](implicit cS: Cogen[String]): Arbitrary[TestAlgebra[T]] =
     Arbitrary {
@@ -88,17 +84,13 @@ object autoFlatMapTests {
         conEff <- Arbitrary.arbitrary[Option[String => T]]
         absOther <- Arbitrary.arbitrary[String => String]
         conOther <- Arbitrary.arbitrary[Option[String => String]]
-        withoutParameters <- Arbitrary.arbitrary[T]
+        noParams <- Arbitrary.arbitrary[T]
       } yield new TestAlgebra[T] {
         override def abstractEffect(i: String): T = absEff(i)
-
         override def concreteEffect(a: String): T = conEff.getOrElse(super.concreteEffect(_))(a)
-
         override def abstractOther(a: String): String = absOther(a)
-
         override def concreteOther(a: String): String = conOther.getOrElse(super.concreteOther(_))(a)
-
-        override def withoutParams: T = withoutParameters
+        override def withoutParams: T = noParams
       }
     }
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoFunctorKTests.scala
@@ -17,31 +17,31 @@
 package cats.tagless
 package tests
 
-
-import scala.util.Try
 import cats.{Monad, Show, ~>}
-import cats.laws.discipline.SerializableTests
-import cats.tagless.laws.discipline.FunctorKTests
-import autoFunctorKTests._
 import cats.arrow.FunctionK
 import cats.free.Free
+import cats.laws.discipline.SerializableTests
+import cats.tagless.laws.discipline.FunctorKTests
 import shapeless.test.illTyped
 
+import scala.util.Try
+
 class autoFunctorKTests extends CatsTaglessTestSuite {
+  import autoFunctorKTests._
+
+  checkAll("FunctorK[SafeAlg]", FunctorKTests[SafeAlg].functorK[Try, Option, List, Int])
+  checkAll("FunctorK is Serializable", SerializableTests.serializable(FunctorK[SafeAlg]))
+
   test("simple mapK") {
-
     val optionParse: SafeAlg[Option] = Interpreters.tryInterpreter.mapK(fk)
-
     optionParse.parseInt("3") should be(Some(3))
     optionParse.parseInt("sd") should be(None)
     optionParse.divide(3f, 3f) should be(Some(1f))
-
   }
 
   test("simple instance summon with autoDeriveFromFunctorK on") {
     implicit val listParse: SafeAlg[List] = Interpreters.tryInterpreter.mapK(λ[Try ~> List](_.toList))
     SafeAlg[List].parseInt("3") should be(List(3))
-
     succeed
   }
 
@@ -51,9 +51,6 @@ class autoFunctorKTests extends CatsTaglessTestSuite {
     SafeAlg[Option]
     succeed
   }
-
-  checkAll("ParseAlg[Option]", FunctorKTests[SafeAlg].functorK[Try, Option, List, Int])
-  checkAll("FunctorK[ParseAlg]", SerializableTests.serializable(FunctorK[SafeAlg]))
 
   test("Alg with non effect method") {
     val tryInt = new AlgWithNonEffectMethod[Try] {
@@ -76,10 +73,10 @@ class autoFunctorKTests extends CatsTaglessTestSuite {
 
 
   test("Alg with extra type parameters") {
-
     implicit val foo: AlgWithExtraTP[Try, String] = new AlgWithExtraTP[Try, String] {
       def a(i: Int) = Try(i.toString)
     }
+
     import AlgWithExtraTP.autoDerive._
     AlgWithExtraTP[Option, String].a(5) should be(Some("5"))
   }
@@ -88,6 +85,7 @@ class autoFunctorKTests extends CatsTaglessTestSuite {
     implicit val algWithExtraTP: AlgWithExtraTP2[String, Try] = new AlgWithExtraTP2[String, Try] {
       def a(i: Int) = Try(i.toString)
     }
+
     algWithExtraTP.mapK(fk).a(5) should be(Some("5"))
   }
 
@@ -138,7 +136,7 @@ class autoFunctorKTests extends CatsTaglessTestSuite {
       def a(i: Int): Try[Int] = util.Success(i)
     }
 
-    illTyped { """ AlgWithoutAutoDerivation.autoDerive """}
+    illTyped("AlgWithoutAutoDerivation.autoDerive")
   }
 
   test("defs with no params") {
@@ -169,8 +167,8 @@ class autoFunctorKTests extends CatsTaglessTestSuite {
     }
 
     import AlgWithAbstractTypeClass.fullyRefined._
-
-    implicit val fShow : FunctorK[AlgWithAbstractTypeClass.Aux[?[_], Show]] = functorKForFullyRefinedAlgWithAbstractTypeClass[Show]  //scalac needs help when abstract type is high order
+    // Scalac needs help when abstract type is high order.
+    implicit val fShow : FunctorK[AlgWithAbstractTypeClass.Aux[?[_], Show]] = functorKForFullyRefinedAlgWithAbstractTypeClass[Show]
     fShow.mapK(foo)(fk).a(true) should be(Some("true"))
   }
 
@@ -244,7 +242,6 @@ object autoFunctorKTests {
     sealed abstract class A
     case object B extends A
     case object C extends A
-
     type Aux[F[_], T0 <: A] = AlgWithTypeBound[F] { type T = T0 }
   }
 

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
@@ -17,15 +17,17 @@
 package cats.tagless
 package tests
 
-
-import scala.util.Try
 import cats.~>
 import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary._
 import cats.tagless.laws.discipline.InvariantKTests
-import autoInvariantKTests._
 import shapeless.test.illTyped
 
+import scala.util.Try
+
 class autoInvariantKTests extends CatsTaglessTestSuite {
+  import autoInvariantKTests._
+
   checkAll("SafeInvAlg[Option]", InvariantKTests[SafeInvAlg].invariantK[Try, Option, List])
   checkAll("InvariantK[SafeInvAlg]", SerializableTests.serializable(InvariantK[SafeInvAlg]))
 

--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantTests.scala
@@ -18,15 +18,14 @@ package cats.tagless
 package tests
 
 
-import cats.laws.discipline.{ExhaustiveCheck, InvariantTests, SerializableTests}
-import autoInvariantTests._
-import cats.Invariant
-import cats.kernel.Eq
-import org.scalacheck.{Arbitrary, Cogen}
+import cats.{Eq, Invariant}
+import cats.instances.all._
+import cats.laws.discipline.{InvariantTests, SerializableTests}
 import cats.laws.discipline.eq._
-
+import org.scalacheck.{Arbitrary, Cogen}
 
 class autoInvariantTests extends CatsTaglessTestSuite {
+  import autoInvariantTests._
 
   checkAll("SimpleAlg[Option]", InvariantTests[SimpleAlg].invariant[Float, String, Int])
   checkAll("Invariant[SimpleAlg]", SerializableTests.serializable(Invariant[SimpleAlg]))
@@ -51,14 +50,16 @@ class autoInvariantTests extends CatsTaglessTestSuite {
     intAlg.imap(_.toString)(_.toInt).plusOne("3") should be("4")
     intAlg.imap(_.toString)(_.toInt).minusOne(2) should be(1)
   }
-
 }
 
 object autoInvariantTests {
+  import TestInstances._
 
   @autoInvariant
   trait SimpleAlg[T] {
     def foo(a: T): T
+    def headOption(ts: List[T]): Option[T]
+    def map[U](ts: List[T])(f: T => U): List[U] = ts.map(f)
   }
 
   @autoInvariant
@@ -110,19 +111,17 @@ object autoInvariantTests {
     def foo(a: String, b: Float): Float = a.length.toFloat + b
   }
 
+  implicit def eqForSimpleAlg[T: Arbitrary: Cogen: Eq]: Eq[SimpleAlg[T]] =
+    Eq.by(algebra => (algebra.foo _, algebra.headOption _, algebra.map[Int] _))
 
-  implicit def eqForSimpleAlg[T: Arbitrary : ExhaustiveCheck](implicit eqT: Eq[T]): Eq[SimpleAlg[T]] =
-    Eq.by[SimpleAlg[T], T => T] { p =>
-      (s: T) => p.foo(s)
-    }
-
-  implicit def arbitrarySimpleAlg[T: ExhaustiveCheck](implicit cS: Cogen[T],
-                                     FI: Arbitrary[T]): Arbitrary[SimpleAlg[T]] =
+  implicit def arbitrarySimpleAlg[T: Arbitrary: Cogen]: Arbitrary[SimpleAlg[T]] =
     Arbitrary {
       for {
         f <- Arbitrary.arbitrary[T => T]
+        hOpt <- Arbitrary.arbitrary[List[T] => Option[T]]
       } yield new SimpleAlg[T] {
         def foo(i: T): T = f(i)
+        def headOption(list: List[T]) = hOpt(list)
       }
     }
 

--- a/tests/src/test/scala/cats/tagless/tests/autoProductNKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoProductNKTests.scala
@@ -17,32 +17,26 @@
 package cats.tagless
 package tests
 
-
 import cats.~>
 
-import util.{Success, Try}
+import scala.util.Try
 
 class autoProductNKTests extends CatsTaglessTestSuite {
+
   test("simple product") {
     val optionInterpreter = Interpreters.tryInterpreter.mapK(λ[Try ~> Option](_.toOption))
     val listInterpreter = optionInterpreter.mapK(λ[Option ~> List](_.toList))
-
     val prodInterpreter: SafeAlg[Tuple3K[Try, List, Option]#λ] =
       SafeAlg.product3K(Interpreters.tryInterpreter, listInterpreter, optionInterpreter)
 
-    prodInterpreter.parseInt("3") should be((Success(3), List(3f), Some(3f)))
+    prodInterpreter.parseInt("3") shouldBe ((Try(3), List(3f), Some(3f)))
     val failure = prodInterpreter.parseInt("3.5")
-
-    failure._1.isFailure should be(true)
-    failure._2 should be(Nil)
-    failure._3 should be(None)
-
-    prodInterpreter.divide(3f, 3f) should be((Success(1f), List(1f), Some(1f)))
-
+    failure._1.isFailure shouldBe true
+    failure._2 shouldBe Nil
+    failure._3 shouldBe None
+    prodInterpreter.divide(3f, 3f) shouldBe ((Try(1f), List(1f), Some(1f)))
   }
-
 }
-
 
 object autoProductNKTests {
 

--- a/tests/src/test/scala/cats/tagless/tests/autoSemigroupalKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoSemigroupalKTests.scala
@@ -17,28 +17,25 @@
 package cats.tagless
 package tests
 
-
 import cats.laws.discipline.SerializableTests
 import cats.tagless.laws.discipline.SemigroupalKTests
 
-import util.{Success, Try}
+import scala.util.Try
 
 class autoSemigroupalKTests extends CatsTaglessTestSuite {
-  test("simple product") {
-
-    val prodInterpreter = Interpreters.tryInterpreter.productK(Interpreters.lazyInterpreter)
-
-    prodInterpreter.parseInt("3").first should be(Success(3))
-    prodInterpreter.parseInt("3").second.value should be(3)
-    prodInterpreter.parseInt("sd").first.isSuccess should be(false)
-    prodInterpreter.divide(3f, 3f).second.value should be(1f)
-
-  }
-
-  implicit def eqT32 = SafeAlg.eqForSafeAlg[Tuple3K[Try, Option, List]#λ] //have to help scalac here
+  // Type inference issue.
+  implicit val eqForSafeAlg = SafeAlg.eqForSafeAlg[Tuple3K[Try, Option, List]#λ]
 
   checkAll("ParseAlg[Option]", SemigroupalKTests[SafeAlg].semigroupalK[Try, Option, List])
   checkAll("SemigroupalK[ParseAlg]", SerializableTests.serializable(SemigroupalK[SafeAlg]))
+
+  test("simple product") {
+    val prodInterpreter = Interpreters.tryInterpreter.productK(Interpreters.lazyInterpreter)
+    prodInterpreter.parseInt("3").first shouldBe Try(3)
+    prodInterpreter.parseInt("3").second.value shouldBe 3
+    prodInterpreter.parseInt("sd").first.isSuccess shouldBe false
+    prodInterpreter.divide(3f, 3f).second.value shouldBe 1f
+  }
 }
 
 object autoSemigroupalKTests {


### PR DESCRIPTION
I was too excited to wait for completing this PR. It's going way smoother than I expected :astonished: 

Derivation based on existing typeclass instances can work for more complex parameter and return types, such as `EitherT`, `List`, `fs2.Stream` and even builder style algebras.

It looks like we only need the `Id1` type alias, not even `Const1`.

TODO:
 - [x] Add instances for `cats.data` types
 - [x] Tests
 - [x] Cleanup

Where should we put instances? In the companion objects or in a `cats.tagless.instances` package?

closes #9 
closes #10 
closes #52 