### PR TITLE
autoProfunctor / bifunctor

### DIFF
--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -17,7 +17,7 @@
 package cats.tagless
 
 import cats.arrow.Profunctor
-import cats.{Contravariant, FlatMap, Functor, Invariant}
+import cats.{Bifunctor, Contravariant, FlatMap, Functor, Invariant}
 
 object Derive {
 
@@ -25,6 +25,7 @@ object Derive {
   def contravariant[F[_]]: Contravariant[F] = macro DeriveMacros.contravariant[F]
   def invariant[F[_]]: Invariant[F] = macro DeriveMacros.invariant[F]
   def profunctor[F[_, _]]: Profunctor[F] = macro DeriveMacros.profunctor[F]
+  def bifunctor[F[_, _]]: Bifunctor[F] = macro DeriveMacros.bifunctor[F]
   def flatMap[F[_]]: FlatMap[F] = macro DeriveMacros.flatMap[F]
 
   /**

--- a/macros/src/main/scala/cats/tagless/MacroUtils.scala
+++ b/macros/src/main/scala/cats/tagless/MacroUtils.scala
@@ -198,10 +198,8 @@ private[tagless] abstract class MacroUtils {
           .find(_.tparams.lengthCompare(1) == 0)
           .fold[Either[String, Defn]](
             Left(s"${cls.name} does not have a higher-kinded type parameter of shape F[_]")
-          )(
-            effectType =>
-              Right(AlgDefn.UnaryAlg(cls, effectType, 1, cls.tparams.filterNot(Set(effectType)))
-            )
+          )(effectType =>
+              Right(AlgDefn.UnaryAlg(cls, effectType, 1, cls.tparams.filterNot(Set(effectType))))
           )
     }
 
@@ -210,8 +208,7 @@ private[tagless] abstract class MacroUtils {
       override def apply(cls: TypeDefinition) =
         cls.tparams.lastOption.filter(_.tparams.isEmpty).fold[Either[String, Defn]](
           Left(s"${cls.name} must have a type paramter of shape F as its last type parameter")
-        )(
-          effectType =>
+        )(effectType =>
             Right(AlgDefn.UnaryAlg(cls, effectType, 0, cls.tparams.dropRight(1)))
         )
     }
@@ -221,8 +218,7 @@ private[tagless] abstract class MacroUtils {
       override def apply(cls: TypeDefinition) =
         cls.tparams.lastOption.fold[Either[String, Defn]](
           Left(s"${cls.name} does not have any type parameter")
-        )(
-          effectType =>
+        )(effectType =>
             Right(AlgDefn.UnaryAlg(cls, effectType, effectType.tparams.length, cls.tparams.dropRight(1)))
         )
     }
@@ -232,7 +228,7 @@ private[tagless] abstract class MacroUtils {
       override def apply(cls: TypeDefinition) =
         cls.tparams.takeRight(2).filter(_.tparams.isEmpty) match {
         case t1 :: t2 :: Nil =>
-            Right(AlgDefn.BinaryAlg(cls, (t1, 0), (t2, 0), cls.tparams.filterNot(Set(t1, t2))))
+            Right(AlgDefn.BinaryAlg(cls, (t1, 0), (t2, 0), cls.tparams.dropRight(2)))
         case _ =>
             Left(
               s"${cls.name} must have two type parameters of shape F as its last type parameters"

--- a/macros/src/main/scala/cats/tagless/MacroUtils.scala
+++ b/macros/src/main/scala/cats/tagless/MacroUtils.scala
@@ -26,7 +26,6 @@ private[tagless] abstract class MacroUtils {
   class TypeDefinition(val defn: ClassDef, maybeCompanion: Option[ModuleDef]) {
     val name = defn.name
     val tparams = defn.tparams
-    val hasOneTypeParam = tparams.lengthCompare(1) == 0
     val impl = defn.impl
 
     def ident = Ident(name)
@@ -83,82 +82,175 @@ private[tagless] abstract class MacroUtils {
     }
   }
 
-  case class AlgDefn(cls: TypeDefinition, effectType: TypeDef, extraTParams: Seq[TypeDef], enriched: List[Tree] = Nil) {
-    def typeName = cls.ident
-    def name = cls.name.decodedName.toString
+  sealed abstract class AlgDefn(numberOfEffectTypeParams: Int) {
+    private val needsTypeLambda = cls.tparams.lengthCompare(numberOfEffectTypeParams) != 0
 
-    private def tArgs(effTpeName: TypeName): List[Ident] = cls.tparams.map {
-      case `effectType` => Ident(effTpeName)
-      case tp =>  Ident(tp.name)
-    }
+    def cls: TypeDefinition
+    final def typeName = cls.ident
+    final def name = cls.name.decodedName.toString
 
-    def newTypeSig(newEffectTypeName: TypeName): AppliedTypeTree = AppliedTypeTree(typeName, tArgs(newEffectTypeName))
-    def newTypeSig(newEffectTypeName: String): AppliedTypeTree = newTypeSig(TypeName(newEffectTypeName))
-    def newTypeSig(newEffectType: TypeDef): AppliedTypeTree = newTypeSig(newEffectType.name)
+    def extraTypeParams: Seq[TypeDef]
 
-    private def refinedTypeSig(newEffectTypeName: TypeName, refinedTypes: Seq[TypeDef]): TypTree = {
-      val typeSig = newTypeSig(newEffectTypeName)
-      if (refinedTypes.isEmpty) typeSig else tq"$typeSig { ..$refinedTypes }".asInstanceOf[CompoundTypeTree]
-    }
-    private def refinedTypeSig(newEffectTypeName: String,  refinedTypes: Seq[TypeDef]): TypTree =
-      refinedTypeSig(TypeName(newEffectTypeName), refinedTypes)
+    protected def typeLambdaVaryingEffect: Tree
+    final def forVaryingEffectType(gen: (Tree, Seq[TypeDef]) => Tree) =
+      gen(if (!needsTypeLambda) typeName else typeLambdaVaryingEffect, extraTypeParams)
 
-    def fullyRefinedTypeSig(newEffectTypeName: String) = refinedTypeSig(newEffectTypeName, cls.fullyRefinedTypeMembers)
-    def fullyRefinedTypeSig(newEffectType: TypeDef) = refinedTypeSig(newEffectType.name, cls.fullyRefinedTypeMembers)
-
-    def dependentRefinedTypeSig(newEffectType: TypeDef, dependent: TermName): TypTree =
-      refinedTypeSig(newEffectType.name, cls.newDependentTypeMembers(dependent))
-
-
-    def withStats(stats: Tree) = copy(enriched = stats :: enriched)
-    def trees = {
-      val enrichedCompanion = addStats(cls.companion, enriched)
-      Seq(cls.defn, enrichedCompanion)
-    }
-
-
-    def forVaryingEffectType(gen: (Tree, Seq[TypeDef]) => Tree) = {
-      val typeLambdaVaryingEffect = if (cls.hasOneTypeParam) typeName else tq"({type λ[T] = ${newTypeSig("T")}})#λ"
-      val newDef = gen(typeLambdaVaryingEffect, extraTParams)
-      withStats(newDef)
-    }
-    def forVaryingHigherKindedEffectType(gen: (Tree, Seq[TypeDef]) => Tree) = {
-      val typeLambdaVaryingHigherKindedEffect = if (cls.hasOneTypeParam) typeName else tq"({type λ[Ƒ[_]] = ${newTypeSig("Ƒ")}})#λ"
-      val newDef = gen(typeLambdaVaryingHigherKindedEffect, extraTParams)
-      withStats(newDef)
-    }
-    def forVaryingHigherKindedEffectTypeFullyRefined(gen: (Tree, Seq[TypeDef]) => Tree) = if (cls.hasAbstractTypeMembers) {
+    protected def typeLambdaVaryingEffectFullyRefined: Tree
+    final def forVaryingEffectTypeFullyRefined(gen: (Tree, Seq[TypeDef]) => Tree) = if (cls.hasAbstractTypeMembers) {
       val typeLambda =
-        if (cls.hasOneTypeParam)
+        if (!needsTypeLambda)
           tq"$typeName { ..${cls.fullyRefinedTypeMembers} }"
-        else tq"({type λ[Ƒ[_]] = ${fullyRefinedTypeSig("Ƒ")}})#λ"
-      val fullyRefinedTypeParams = extraTParams ++ cls.refinedTParams
+        else
+          typeLambdaVaryingEffectFullyRefined
+      val fullyRefinedTypeParams = extraTypeParams ++ cls.refinedTParams
+      gen(typeLambda, fullyRefinedTypeParams)
+    } else forVaryingEffectType(gen)
 
-      val newDef = gen(typeLambda, fullyRefinedTypeParams)
-      withStats(newDef)
-    } else forVaryingHigherKindedEffectType(gen)
-
-    def forAlgebraType(gen: (AppliedTypeTree, Seq[TypeDef]) => Tree) = withStats(gen(cls.typeSig, cls.tparams))
+    final def forAlgebraType(gen: (AppliedTypeTree, Seq[TypeDef]) => Tree) = gen(cls.typeSig, cls.tparams)
   }
 
   object AlgDefn {
-    def from(cls: TypeDefinition, higherKinded: Boolean = true): Option[AlgDefn] = {
-      { if (higherKinded)
-        cls.tparams.find(_.tparams.nonEmpty)
-      else
-        cls.tparams.lastOption
-      }.map(effectType =>
-        AlgDefn(cls, effectType, cls.tparams.filterNot(Set(effectType)))
-      )
+
+    case class UnaryAlg(override val cls: TypeDefinition,
+                        effectType: TypeDef, effectTypeArity: Int,
+                        override val extraTypeParams: Seq[TypeDef]) extends AlgDefn(1) {
+      private def tArgs(effTpeName: TypeName): List[Ident] = cls.tparams.map {
+        case `effectType` => Ident(effTpeName)
+        case tp =>  Ident(tp.name)
+      }
+
+      def newTypeSig(newEffectTypeName: TypeName): AppliedTypeTree = AppliedTypeTree(typeName, tArgs(newEffectTypeName))
+      def newTypeSig(newEffectTypeName: String): AppliedTypeTree = newTypeSig(TypeName(newEffectTypeName))
+      def newTypeSig(newEffectType: TypeDef): AppliedTypeTree = newTypeSig(newEffectType.name)
+
+      private def refinedTypeSig(newEffectTypeName: TypeName, refinedTypes: Seq[TypeDef]): TypTree = {
+        val typeSig = newTypeSig(newEffectTypeName)
+        if (refinedTypes.isEmpty) typeSig else tq"$typeSig { ..$refinedTypes }".asInstanceOf[CompoundTypeTree]
+      }
+      private def refinedTypeSig(newEffectTypeName: String,  refinedTypes: Seq[TypeDef]): TypTree =
+        refinedTypeSig(TypeName(newEffectTypeName), refinedTypes)
+
+      def fullyRefinedTypeSig(newEffectTypeName: String) = refinedTypeSig(newEffectTypeName, cls.fullyRefinedTypeMembers)
+      def fullyRefinedTypeSig(newEffectType: TypeDef) = refinedTypeSig(newEffectType.name, cls.fullyRefinedTypeMembers)
+
+      def dependentRefinedTypeSig(newEffectType: TypeDef, dependent: TermName): TypTree =
+        refinedTypeSig(newEffectType.name, cls.newDependentTypeMembers(dependent))
+
+      override protected def typeLambdaVaryingEffect =
+        tq"({type λ[${createTypeParam("Ƒ", effectTypeArity)}] = ${newTypeSig("Ƒ")}})#λ"
+      override protected def typeLambdaVaryingEffectFullyRefined =
+        tq"({type λ[${createTypeParam("Ƒ", effectTypeArity)}] = ${fullyRefinedTypeSig("Ƒ")}})#λ"
     }
+
+    case class BinaryAlg(override val cls: TypeDefinition,
+                         effectType1: (TypeDef, Int),
+                         effectType2: (TypeDef, Int),
+                         override val extraTypeParams: Seq[TypeDef]) extends AlgDefn(2) {
+      private def tArgs(effTpeName1: TypeName, effTpeName2: TypeName): List[Ident] = cls.tparams.map(
+        tp =>
+          if (tp == effectType1._1) Ident(effTpeName1)
+          else if (tp == effectType2._1) Ident(effTpeName2)
+          else Ident(tp.name)
+      )
+
+      def newTypeSig(newEffectTypeName1: TypeName, newEffectTypeName2: TypeName): AppliedTypeTree =
+        AppliedTypeTree(typeName, tArgs(newEffectTypeName1, newEffectTypeName2))
+      def newTypeSig(newEffectTypeName1: String, newEffectTypeName2: String): AppliedTypeTree =
+        newTypeSig(TypeName(newEffectTypeName1), TypeName(newEffectTypeName2))
+
+      private def refinedTypeSig(newEffectTypeName1: TypeName, newEffectTypeName2: TypeName, refinedTypes: Seq[TypeDef]): TypTree = {
+        val typeSig = newTypeSig(newEffectTypeName1, newEffectTypeName2)
+        if (refinedTypes.isEmpty) typeSig else tq"$typeSig { ..$refinedTypes }".asInstanceOf[CompoundTypeTree]
+      }
+      private def refinedTypeSig(newEffectTypeName1: String, newEffectTypeName2: String,  refinedTypes: Seq[TypeDef]): TypTree =
+        refinedTypeSig(TypeName(newEffectTypeName1), TypeName(newEffectTypeName2), refinedTypes)
+
+      def fullyRefinedTypeSig(newEffectTypeName1: String, newEffectTypeName2: String) =
+        refinedTypeSig(newEffectTypeName1, newEffectTypeName2, cls.fullyRefinedTypeMembers)
+
+      private def asTypeParams(name1: String, name2: String) =
+        List(createTypeParam(name1, effectType1._2), createTypeParam(name2, effectType2._2))
+      override protected def typeLambdaVaryingEffect =
+        tq"({type λ[..${asTypeParams("Ƒ1", "Ƒ2")}] = ${newTypeSig("Ƒ1", "Ƒ2")}})#λ"
+      override protected def typeLambdaVaryingEffectFullyRefined =
+        tq"({type λ[..${asTypeParams("Ƒ1", "Ƒ2")}] = ${fullyRefinedTypeSig("Ƒ1", "Ƒ2")}})#λ"
+    }
+
   }
 
-  def enrichAlgebra(defn: Seq[c.Tree], higherKinded: Boolean = true)(f: AlgDefn => AlgDefn): Tree = {
-    enrich(defn){ cls =>
-      val ad = AlgDefn.from(cls, higherKinded).getOrElse(abort(if (higherKinded) s"${cls.name} does not have an higher-kinded type parameter, e.g. F[_]"
-                                                               else s"${cls.name} does not have any type parameter"))
-      val enriched = f(ad)
-      enriched.trees
+  sealed abstract class AlgebraResolver {
+    type Defn <: AlgDefn
+    def apply(cls: TypeDefinition): Either[String, Defn]
+  }
+
+  object AlgebraResolver {
+    type Unary = AlgebraResolver {
+      type Defn = AlgDefn.UnaryAlg
+    }
+    type Binary = AlgebraResolver {
+      type Defn = AlgDefn.BinaryAlg
+    }
+
+    def FirstHigherKindedTypeParam: Unary = new AlgebraResolver {
+      override type Defn = AlgDefn.UnaryAlg
+      override def apply(cls: TypeDefinition) =
+        cls.tparams
+          .find(_.tparams.lengthCompare(1) == 0)
+          .fold[Either[String, Defn]](
+            Left(s"${cls.name} does not have a higher-kinded type parameter of shape F[_]")
+          )(
+            effectType =>
+              Right(AlgDefn.UnaryAlg(cls, effectType, 1, cls.tparams.filterNot(Set(effectType)))
+            )
+          )
+    }
+
+    def LastRegularTypeParam: Unary = new AlgebraResolver {
+      override type Defn = AlgDefn.UnaryAlg
+      override def apply(cls: TypeDefinition) =
+        cls.tparams.lastOption.filter(_.tparams.isEmpty).fold[Either[String, Defn]](
+          Left(s"${cls.name} must have a type paramter of shape F as its last type parameter")
+        )(
+          effectType =>
+            Right(AlgDefn.UnaryAlg(cls, effectType, 0, cls.tparams.dropRight(1)))
+        )
+    }
+
+    def AnyLastTypeParam: Unary = new AlgebraResolver {
+      override type Defn = AlgDefn.UnaryAlg
+      override def apply(cls: TypeDefinition) =
+        cls.tparams.lastOption.fold[Either[String, Defn]](
+          Left(s"${cls.name} does not have any type parameter")
+        )(
+          effectType =>
+            Right(AlgDefn.UnaryAlg(cls, effectType, effectType.tparams.length, cls.tparams.dropRight(1)))
+        )
+    }
+
+    def TwoLastRegularTypeParams: Binary = new AlgebraResolver {
+      override type Defn = AlgDefn.BinaryAlg
+      override def apply(cls: TypeDefinition) =
+        cls.tparams.takeRight(2).filter(_.tparams.isEmpty) match {
+        case t1 :: t2 :: Nil =>
+            Right(AlgDefn.BinaryAlg(cls, (t1, 0), (t2, 0), cls.tparams.filterNot(Set(t1, t2))))
+        case _ =>
+            Left(
+              s"${cls.name} must have two type parameters of shape F as its last type parameters"
+            )
+      }
+    }
+
+  }
+
+  def enrichAlgebra[A <: AlgebraResolver](defn: Seq[c.Tree], resolver: A = AlgebraResolver.FirstHigherKindedTypeParam)(
+    f: resolver.Defn => Seq[Tree]): Tree = {
+    enrich(defn) { cls =>
+      resolver(cls) match {
+        case Right(ad) =>
+          val enrichedCompanion = addStats(cls.companion, f(ad))
+          Seq(cls.defn, enrichedCompanion)
+        case Left(err) => abort(err)
+      }
     }
   }
 

--- a/macros/src/main/scala/cats/tagless/autoApplyK.scala
+++ b/macros/src/main/scala/cats/tagless/autoApplyK.scala
@@ -37,9 +37,9 @@ private [tagless] class autoApplyKMacros(override val c: whitebox.Context) exten
       q"_root_.cats.tagless.Derive.applyK[$algebraType]"
     )
 
-  def instanceDef(algebra: AlgDefn): AlgDefn =
-    algebra.forVaryingHigherKindedEffectType(generateApplyKFor(algebra.name))
+  def instanceDef(algebra: AlgDefn.UnaryAlg): Tree =
+    algebra.forVaryingEffectType(generateApplyKFor(algebra.name))
 
   def newDef(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList)(instanceDef _ andThen companionMapKDef andThen autoDerivationDef)
+    enrichAlgebra(annottees.toList)(algebra => instanceDef(algebra) :: companionMapKDef(algebra) :: autoDerivationDef(algebra) :: Nil)
 }

--- a/macros/src/main/scala/cats/tagless/autoBifunctor.scala
+++ b/macros/src/main/scala/cats/tagless/autoBifunctor.scala
@@ -19,28 +19,26 @@ import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.collection.immutable.Seq
 import scala.reflect.macros.whitebox
 
-/** Auto generates an instance of `cats.arrow.Profunctor`. */
-@compileTimeOnly("Cannot expand @autoProfunctor")
-class autoProfunctor extends StaticAnnotation {
-  def macroTransform(annottees: Any*): Any = macro autoProfunctorMacros.profunctorInst
+/** Auto generates an instance of `cats.Bifunctor.` */
+@compileTimeOnly("Cannot expand @autoBifunctor")
+class autoBifunctor extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoBifunctorMacros.bifunctorInst
 }
 
-private[tagless] class autoProfunctorMacros(override val c: whitebox.Context) extends MacroUtils {
+private[tagless] class autoBifunctorMacros(override val c: whitebox.Context) extends MacroUtils {
   import c.universe._
 
-  private def generateProfunctorFor(
-    algebraName: String
-  )(algebraType: Tree, typeParams: Seq[TypeDef]) =
+  private def generateBifunctorFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
     typeClassInstance(
-      TermName("profunctorFor" + algebraName),
+      TermName("bifunctorFor" + algebraName),
       typeParams,
-      tq"_root_.cats.arrow.Profunctor[$algebraType]",
-      q"_root_.cats.tagless.Derive.profunctor[$algebraType]"
+      tq"_root_.cats.Bifunctor[$algebraType]",
+      q"_root_.cats.tagless.Derive.bifunctor[$algebraType]"
     )
 
-  def profunctorInst(annottees: c.Tree*): c.Tree =
+  def bifunctorInst(annottees: c.Tree*): c.Tree =
     enrichAlgebra(annottees.toList, AlgebraResolver.TwoLastRegularTypeParams) {
       algebra =>
-        algebra.forVaryingEffectType(generateProfunctorFor(algebra.name)) :: Nil
+        algebra.forVaryingEffectType(generateBifunctorFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/autoContravariant.scala
+++ b/macros/src/main/scala/cats/tagless/autoContravariant.scala
@@ -38,7 +38,7 @@ private[tagless] class autoContravariantMacros(override val c: whitebox.Context)
     )
 
   def contravariantInst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false) { algebra =>
-      algebra.forVaryingEffectType(generateContravariantFor(algebra.name))
+    enrichAlgebra(annottees.toList, AlgebraResolver.LastRegularTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateContravariantFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/autoFlatMap.scala
+++ b/macros/src/main/scala/cats/tagless/autoFlatMap.scala
@@ -39,7 +39,7 @@ private[tagless] class autoFlatMapMacros(override val c: whitebox.Context) exten
     )
 
   def flatMapInst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false) { algebra =>
-      algebra.forVaryingEffectType(generateFlatMapFor(algebra.name))
+    enrichAlgebra(annottees.toList, AlgebraResolver.LastRegularTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateFlatMapFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/autoFunctor.scala
+++ b/macros/src/main/scala/cats/tagless/autoFunctor.scala
@@ -39,7 +39,7 @@ private[tagless] class autoFunctorMacros(override val c: whitebox.Context) exten
     )
 
   def functorInst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false) { algebra =>
-      algebra.forVaryingEffectType(generateFunctorFor(algebra.name))
+    enrichAlgebra(annottees.toList, AlgebraResolver.LastRegularTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateFunctorFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/autoFunctorK.scala
+++ b/macros/src/main/scala/cats/tagless/autoFunctorK.scala
@@ -37,11 +37,11 @@ private [tagless] class autoFunctorKMacros(override val c: whitebox.Context) ext
       q"_root_.cats.tagless.Derive.functorK[$algebraType]"
     )
 
-  def instanceDef(algebra: AlgDefn): AlgDefn =
-    algebra.forVaryingHigherKindedEffectType(generateFunctorKFor(algebra.name))
+  def instanceDef(algebra: AlgDefn.UnaryAlg): Tree =
+    algebra.forVaryingEffectType(generateFunctorKFor(algebra.name))
 
-  def instanceDefFullyRefined(algDefn: AlgDefn): AlgDefn = {
-    algDefn.forVaryingHigherKindedEffectTypeFullyRefined {
+  def instanceDefFullyRefined(algDefn: AlgDefn.UnaryAlg): Tree = {
+    algDefn.forVaryingEffectTypeFullyRefined {
       (algebraType, tparams) =>
         val impl = Seq(
           generateFunctorKFor("FullyRefined" + algDefn.name)(
@@ -58,20 +58,21 @@ private [tagless] class autoFunctorKMacros(override val c: whitebox.Context) ext
   }
 
   def newDef(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList)(instanceDef _ andThen companionMapKDef andThen instanceDefFullyRefined andThen autoDerivationDef)
+    enrichAlgebra(annottees.toList)(
+      algebra => instanceDef(algebra) :: companionMapKDef(algebra) :: instanceDefFullyRefined(algebra) :: autoDerivationDef(algebra) :: Nil)
 }
 
 private [tagless] trait CovariantKMethodsGenerator { self: MacroUtils =>
   import c.universe._
 
-  def companionMapKDef(algDefn: AlgDefn) = {
+  def companionMapKDef(algDefn: AlgDefn.UnaryAlg) = {
     val from = TermName("af")
     val F = createFreshTypeParam("F", 1)
     val G = createFreshTypeParam("G", 1)
     val algebraF = algDefn.newTypeSig(F)
     val fullyRefinedAlgebraG = algDefn.dependentRefinedTypeSig(G, from)
 
-    algDefn.forVaryingHigherKindedEffectType((algebraType, tparams) => q"""
+    algDefn.forVaryingEffectType((algebraType, tparams) => q"""
       def mapK[$F, $G, ..$tparams]($from: $algebraF)(fk: _root_.cats.~>[..${tArgs(F, G)}]): $fullyRefinedAlgebraG =
         _root_.cats.tagless.FunctorK[$algebraType].mapK($from)(fk).asInstanceOf[$fullyRefinedAlgebraG]
     """)
@@ -94,7 +95,7 @@ private [tagless] trait CovariantKMethodsGenerator { self: MacroUtils =>
       }"""
   }
 
-  def autoDerivationDef(algDefn: AlgDefn) =
-    if(autoDerive) algDefn.forVaryingHigherKindedEffectType(generateAutoDerive(algDefn.newTypeSig)) else algDefn
+  def autoDerivationDef(algDefn: AlgDefn.UnaryAlg) =
+    if(autoDerive) algDefn.forVaryingEffectType(generateAutoDerive(algDefn.newTypeSig)) else EmptyTree
 
 }

--- a/macros/src/main/scala/cats/tagless/autoInvariant.scala
+++ b/macros/src/main/scala/cats/tagless/autoInvariant.scala
@@ -38,7 +38,7 @@ private[tagless] class autoInvariantMacros(override val c: whitebox.Context) ext
     )
 
   def invariantInst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false) { algebra =>
-      algebra.forVaryingEffectType(generateInvariantFor(algebra.name))
+    enrichAlgebra(annottees.toList, AlgebraResolver.LastRegularTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateInvariantFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/autoInvariantK.scala
+++ b/macros/src/main/scala/cats/tagless/autoInvariantK.scala
@@ -37,11 +37,11 @@ private [tagless] class autoInvariantKMacros(override val c: whitebox.Context) e
       q"_root_.cats.tagless.Derive.invariantK[$algebraType]"
     )
 
-  def instanceDef(algebra: AlgDefn): AlgDefn =
-    algebra.forVaryingHigherKindedEffectType(generateInvariantKFor(algebra.name))
+  def instanceDef(algebra: AlgDefn.UnaryAlg): Tree =
+    algebra.forVaryingEffectType(generateInvariantKFor(algebra.name))
 
-  def instanceDefFullyRefined(algDefn: AlgDefn): AlgDefn = {
-    algDefn.forVaryingHigherKindedEffectTypeFullyRefined {
+  def instanceDefFullyRefined(algDefn: AlgDefn.UnaryAlg): Tree = {
+    algDefn.forVaryingEffectTypeFullyRefined {
       (algebraType, tparams) =>
         val impl = Seq(
           generateInvariantKFor("FullyRefined" + algDefn.name)(
@@ -57,14 +57,14 @@ private [tagless] class autoInvariantKMacros(override val c: whitebox.Context) e
     }
   }
 
-  def companionIMapKDef(algDefn: AlgDefn) = {
+  def companionIMapKDef(algDefn: AlgDefn.UnaryAlg) = {
     val from = TermName("af")
     val F = createFreshTypeParam("F", 1)
     val G = createFreshTypeParam("G", 1)
     val algebraF = algDefn.newTypeSig(F)
     val fullyRefinedAlgebraG = algDefn.dependentRefinedTypeSig(G, from)
 
-    algDefn.forVaryingHigherKindedEffectType((algebraType, tparams) => q"""
+    algDefn.forVaryingEffectType((algebraType, tparams) => q"""
       def imapK[$F, $G, ..$tparams]($from: $algebraF)(fk: _root_.cats.~>[..${tArgs(F, G)}])(gk: _root_.cats.~>[..${tArgs(G, F)}]): $fullyRefinedAlgebraG =
         _root_.cats.tagless.InvariantK[$algebraType].imapK($from)(fk)(gk).asInstanceOf[$fullyRefinedAlgebraG]
     """)
@@ -88,9 +88,9 @@ private [tagless] class autoInvariantKMacros(override val c: whitebox.Context) e
       }"""
   }
 
-  def autoDerivationDef(algDefn: AlgDefn) =
-    if(autoDerive) algDefn.forVaryingHigherKindedEffectType(generateAutoDerive(algDefn.newTypeSig)) else algDefn
+  def autoDerivationDef(algDefn: AlgDefn.UnaryAlg) =
+    if(autoDerive) algDefn.forVaryingEffectType(generateAutoDerive(algDefn.newTypeSig)) else EmptyTree
 
   def newDef(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList)(instanceDef _ andThen companionIMapKDef andThen instanceDefFullyRefined andThen autoDerivationDef)
+    enrichAlgebra(annottees.toList)(algebra => instanceDef(algebra) :: companionIMapKDef(algebra) :: instanceDefFullyRefined(algebra) :: autoDerivationDef(algebra) :: Nil)
 }

--- a/macros/src/main/scala/cats/tagless/autoProfunctor.scala
+++ b/macros/src/main/scala/cats/tagless/autoProfunctor.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
+import scala.reflect.macros.whitebox
+
+/** Auto generates an instance of `cats.Functor`. */
+@compileTimeOnly("Cannot expand @autoProfunctor")
+class autoProfunctor extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoProfunctorMacros.profunctorInst
+}
+
+private[tagless] class autoProfunctorMacros(override val c: whitebox.Context) extends MacroUtils {
+  import c.universe._
+
+  private def generateProfunctorFor(
+    algebraName: String
+  )(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("profunctorFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.arrow.Profunctor[$algebraType]",
+      q"_root_.cats.tagless.Derive.profunctor[$algebraType]"
+    )
+
+  def profunctorInst(annottees: c.Tree*): c.Tree =
+    enrichAlgebra(annottees.toList, AlgebraResolver.TwoLastRegularTypeParams) {
+      algebra =>
+        algebra.forVaryingEffectType(generateProfunctorFor(algebra.name)) :: Nil
+    }
+}

--- a/macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
+++ b/macros/src/main/scala/cats/tagless/autoSemigroupalK.scala
@@ -39,6 +39,6 @@ private[tagless] class autoSemigroupalKMacros(override val c: whitebox.Context) 
 
   def semigroupalKInst(annottees: c.Tree*): c.Tree =
     enrichAlgebra(annottees.toList) { algebra =>
-      algebra.forVaryingHigherKindedEffectType(generateSemigroupalKFor(algebra.name))
+      algebra.forVaryingEffectType(generateSemigroupalKFor(algebra.name)) :: Nil
     }
 }

--- a/macros/src/main/scala/cats/tagless/finalAlg.scala
+++ b/macros/src/main/scala/cats/tagless/finalAlg.scala
@@ -32,8 +32,8 @@ private[tagless] class finalAlgMacros(override val c: whitebox.Context) extends 
     q"def apply[..$tparams](implicit inst: $algebraType): $algebraType = inst"
 
   def inst(annottees: c.Tree*): c.Tree =
-    enrichAlgebra(annottees.toList, higherKinded = false)(
-      _.forAlgebraType(generateApply)
+    enrichAlgebra(annottees.toList, AlgebraResolver.AnyLastTypeParam)(algebra =>
+      algebra.forAlgebraType(generateApply) :: Nil
     )
 
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoBifunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoBifunctorTests.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Kailuo Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+import cats.Bifunctor
+import cats.instances.AllInstances
+import cats.kernel.Eq
+import cats.laws.discipline.{BifunctorTests, SerializableTests}
+import cats.tagless.autoBifunctor
+import org.scalacheck.Arbitrary
+import cats.laws.discipline.eq._
+
+class autoBifunctorTests extends CatsTaglessTestSuite {
+  import autoBifunctorTests._
+
+  checkAll("Bifunctor[TestAlgebra]", BifunctorTests[TestAlgebra].bifunctor[String, Boolean, Option[String], Int, String, List[Int]])
+  checkAll("Serializable Bifunctor[TestAlgebra]", SerializableTests.serializable(Bifunctor[TestAlgebra]))
+
+  test("extra type param correctly handled") {
+    val transformedAlg = AlgWithExtraTypeParamString.bimap(i => if (i > 0) Some(i) else None, new String(_))
+    transformedAlg.foo("") should be(None)
+    transformedAlg.foo("1") should be(Some(1))
+    transformedAlg.boo("adsfdsd") should be("adsfdsd")
+  }
+}
+
+object autoBifunctorTests extends TestInstances with AllInstances {
+
+  @autoBifunctor
+  trait TestAlgebra[A, B] {
+    def left: A
+    def right: B
+    final def toTuple: (A, B) = (left, right)
+    final def mapLeft[C](f: A => C): C = f(left)
+    final def mapRight[C](f: B => C): C = f(right)
+
+    def concreteMethod: Int = 0
+    def fromInt(i: Int): A
+    def fromString(s: String): B
+  }
+
+  object TestAlgebra {
+    implicit def eqv[A: Eq, B: Eq]: Eq[TestAlgebra[A, B]] =
+      Eq.by { algebra =>
+        (
+          algebra.left,
+          algebra.right,
+          algebra.fromInt _,
+          algebra.fromString _,
+          algebra.concreteMethod
+        )
+      }
+  }
+
+  implicit def arbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[TestAlgebra[A, B]] =
+    Arbitrary(for {
+      a1 <- Arbitrary.arbitrary[A]
+      a2 <- Arbitrary.arbitrary[A]
+      b <- Arbitrary.arbitrary[B]
+      int <- Arbitrary.arbitrary[Int]
+    } yield new TestAlgebra[A, B] {
+      override def left: A = a1
+      override def right: B = b
+      override def concreteMethod = int
+      override def fromInt(i: Int) = if (i > 0) left else a2
+      override def fromString(s: String) = b
+    })
+
+  @autoBifunctor
+  trait AlgWithExtraTypeParam[T, A, B] {
+    def foo(t: T): A
+    def boo(t: T): B
+  }
+
+  object AlgWithExtraTypeParamString extends AlgWithExtraTypeParam[String, Int, Array[Char]] {
+    override def foo(t: String) = t.length
+    override def boo(t: String) = t.toCharArray
+  }
+
+}

--- a/tests/src/test/scala/cats/tagless/tests/autoProfunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoProfunctorTests.scala
@@ -33,7 +33,7 @@ class autoProfunctorTests extends CatsTaglessTestSuite {
 object autoProfunctorTests {
    import TestInstances._
 
-  // TODO: Macro annotation.
+  @autoProfunctor
   trait TestAlgebra[A, B] {
     def abstractCovariant(str: String): B
     def concreteCovariant(str: String): B = abstractCovariant(str + " concreteCovariant")
@@ -47,8 +47,6 @@ object autoProfunctorTests {
   }
 
   object TestAlgebra {
-    implicit val profunctor: Profunctor[TestAlgebra] = Derive.profunctor
-
     implicit def eqv[A: Arbitrary: ExhaustiveCheck, B: Eq]: Eq[TestAlgebra[A, B]] =
       Eq.by { algebra =>
         (
@@ -87,4 +85,5 @@ object autoProfunctorTests {
       override def concreteOther(str: String): String = conOther.getOrElse(super.concreteOther(_))(str)
       override def withoutParams: B = withoutParameters
     })
+
 }

--- a/tests/src/test/scala/cats/tagless/tests/autoProfunctorTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoProfunctorTests.scala
@@ -28,6 +28,11 @@ import org.scalacheck.{Arbitrary, Cogen}
 class autoProfunctorTests extends CatsTaglessTestSuite {
   checkAll("Profunctor[TestAlgebra]", ProfunctorTests[TestAlgebra].profunctor[Long, String, Int, Long, String, Int])
   checkAll("Serializable Profunctor[TestAlgebra]", SerializableTests.serializable(Profunctor[TestAlgebra]))
+
+  test("extra type param correctly handled") {
+    val asStringAlg = AlgWithExtraTypeParamString.dimap((s: String) => s.length)(_ + 1)
+    asStringAlg.foo("base", "x2") should be(9d)
+  }
 }
 
 object autoProfunctorTests {
@@ -85,5 +90,14 @@ object autoProfunctorTests {
       override def concreteOther(str: String): String = conOther.getOrElse(super.concreteOther(_))(str)
       override def withoutParams: B = withoutParameters
     })
+
+  @autoProfunctor
+  trait AlgWithExtraTypeParam[T, A, B] {
+    def foo(t: T, a: A): B
+  }
+
+  object AlgWithExtraTypeParamString extends AlgWithExtraTypeParam[String, Int, Double] {
+    override def foo(t: String, a: Int) = t.length * a.toDouble
+  }
 
 }


### PR DESCRIPTION
Adds `@autoProfunctor` annotation (see #48 ).

I needed to add more elaborate handling of algebra "shapes". Before profunctor the code had had to deal with rather limited set of algebras - `Alg[F[_], ...]` or `Alg[F,..]`, while to support profunctor (and, later, bifunctor) one had to consider `Alg[F1, F2]` . I decided to go with rather elaborate machinery of `AlgebraResolver` which produces metadata about the algebra being processed based on the expected position and kind of effect type params eg. `AnyLastTypeParam` or `FirstHigherKindedTypeParam`. The expected type of algebra (currently either `UnaryAlgebra` or `BinaryAlgebra`) is carried as its type member and used as a dependent type in `enrichAlgebra`. While this might be a cognitive overkill, it has some nice properties compared to reimplementing algebra definition to use `Seq` or something similar:
- you cannot use something like `newTypeSig(..)` with wrong number of params
- you can catch errors earlier eg. the difference between `@finalAlg` and `@autoFunctor`
- it has the potential for better error reporting (see #52 )

Please review