### PR TITLE
Add ContravariantK typeclass and derivation

### DIFF
--- a/core/src/main/scala/cats/tagless/ContravariantK.scala
+++ b/core/src/main/scala/cats/tagless/ContravariantK.scala
@@ -15,10 +15,18 @@
  */
 
 package cats.tagless
-package syntax
 
-trait AllSyntax extends FunctorKSyntax
-  with ContravariantKSyntax
-  with InvariantKSyntax
-  with SemigroupalKSyntax
-  with ApplyKSyntax
+import cats.~>
+import simulacrum.typeclass
+
+/** A higher-kinded `Contravariant` functor.
+  * Must obey the laws in `cats.tagless.laws.ContravariantKLaws`.
+  */
+@typeclass trait ContravariantK[A[_[_]]] extends InvariantK[A] {
+  def contramapK[F[_], G[_]](af: A[F])(fk: G ~> F): A[G]
+  override def imapK[F[_], G[_]](af: A[F])(fk: F ~> G)(gk: G ~> F): A[G] = contramapK(af)(gk)
+}
+
+
+
+

--- a/core/src/main/scala/cats/tagless/instances/AllInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/AllInstances.scala
@@ -22,6 +22,7 @@ trait AllInstances extends EitherKInstances
   with IdTInstances
   with IorTInstances
   with KleisliInstances
+  with CokleisliInstances
   with NestedInstances
   with OneAndInstances
   with OptionTInstances

--- a/core/src/main/scala/cats/tagless/instances/CokleisliInstances.scala
+++ b/core/src/main/scala/cats/tagless/instances/CokleisliInstances.scala
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-package cats.tagless
-package syntax
+package cats.tagless.instances
 
-trait AllSyntax extends FunctorKSyntax
-  with ContravariantKSyntax
-  with InvariantKSyntax
-  with SemigroupalKSyntax
-  with ApplyKSyntax
+import cats.data.Cokleisli
+import cats.tagless.ContravariantK
+import cats.~>
+
+trait CokleisliInstances {
+
+  implicit def catsTaglessContravariantKForCokleisli[A, B]: ContravariantK[Cokleisli[?[_], A, B]] =
+    cokleisliInstance.asInstanceOf[ContravariantK[Cokleisli[?[_], A, B]]]
+
+  private[this] val cokleisliInstance: ContravariantK[Cokleisli[?[_], Any, Any]] =
+    new ContravariantK[Cokleisli[?[_], Any, Any]] {
+      def contramapK[F[_], G[_]](af: Cokleisli[F, Any, Any])(fk: G ~> F) = Cokleisli(ga => af.run(fk(ga)))
+    }
+}

--- a/core/src/main/scala/cats/tagless/instances/package.scala
+++ b/core/src/main/scala/cats/tagless/instances/package.scala
@@ -24,6 +24,7 @@ package object instances {
   object idT extends IdTInstances
   object iorT extends IorTInstances
   object kleisli extends KleisliInstances
+  object cokleisli extends CokleisliInstances
   object nested extends NestedInstances
   object oneAnd extends OneAndInstances
   object optionT extends OptionTInstances

--- a/core/src/main/scala/cats/tagless/syntax/ContravariantKSyntax.scala
+++ b/core/src/main/scala/cats/tagless/syntax/ContravariantKSyntax.scala
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-package cats.tagless
-package syntax
+package cats.tagless.syntax
 
-trait AllSyntax extends FunctorKSyntax
-  with ContravariantKSyntax
-  with InvariantKSyntax
-  with SemigroupalKSyntax
-  with ApplyKSyntax
+import cats.tagless.ContravariantK
+
+trait ContravariantKSyntax extends ContravariantK.ToContravariantKOps

--- a/core/src/main/scala/cats/tagless/syntax/package.scala
+++ b/core/src/main/scala/cats/tagless/syntax/package.scala
@@ -19,6 +19,7 @@ package cats.tagless
 package object syntax {
   object all extends AllSyntax
   object functorK extends FunctorKSyntax
+  object contravariantK extends ContravariantKSyntax
   object invariantK extends InvariantKSyntax
   object semigroupalK extends SemigroupalKSyntax
   object applyK extends ApplyKSyntax

--- a/docs/src/main/tut/typeclasses.md
+++ b/docs/src/main/tut/typeclasses.md
@@ -20,6 +20,13 @@ Currently there are four type classes defined in Cats-tagless: [FunctorK](#funct
 
 For tagless final algebras whose effect `F` appears only in the covariant position, instance of `FunctorK` can be auto generated through the `autoFunctorK` annotation.
 
+### <a id="functorK" href="#functorK"></a>`FunctorK` 
+```
+  def contramapK[F[_], G[_]](af: A[F])(fk: G ~> F): A[G]
+```
+
+For tagless final algebras whose effect `F` appears only in the contravariant position, instance of `ContravariantK` can be auto generated through the `autoContravariantK` annotation.
+
 ### <a id="invariantK" href="#invariantK"></a>`InvariantK` 
 ```
   def imapK[F[_], G[_]](af: A[F])(fk: F ~> G)(gK: G ~> F): A[G]

--- a/laws/src/main/scala/cats/tagless/laws/ContravariantKLaws.scala
+++ b/laws/src/main/scala/cats/tagless/laws/ContravariantKLaws.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.laws
+
+import cats.arrow.FunctionK
+import cats.laws._
+import cats.tagless.ContravariantK
+import cats.tagless.syntax.contravariantK._
+import cats.~>
+
+trait ContravariantKLaws[F[_[_]]] extends InvariantKLaws[F]{
+  implicit def F: ContravariantK[F]
+
+  def contravariantIdentity[A[_]](fg: F[A]): IsEq[F[A]] =
+    fg.contramapK(FunctionK.id[A]) <-> fg
+
+  def contravariantComposition[A[_], B[_], C[_]](fa: F[A], f: B ~> A, g: C ~> B): IsEq[F[C]] =
+    fa.contramapK(f).contramapK(g) <-> fa.contramapK(f compose g)
+}
+
+object ContravariantKLaws {
+  def apply[F[_[_]]](implicit ev: ContravariantK[F]): ContravariantKLaws[F] =
+    new ContravariantKLaws[F] { def F = ev }
+}

--- a/laws/src/main/scala/cats/tagless/laws/discipline/ContravariantKTests.scala
+++ b/laws/src/main/scala/cats/tagless/laws/discipline/ContravariantKTests.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.laws.discipline
+
+import cats.laws.discipline._
+import cats.tagless.ContravariantK
+import cats.tagless.laws.ContravariantKLaws
+import cats.{Eq, ~>}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+
+trait ContravariantKTests[F[_[_]]] extends InvariantKTests[F] {
+  def laws: ContravariantKLaws[F]
+
+  def contravariantK[A[_], B[_], C[_], T: Arbitrary](
+    implicit
+    arbFa: Arbitrary[F[A]],
+    arbFkAB: Arbitrary[A ~> B],
+    arbFkBC: Arbitrary[B ~> C],
+    arbFkBA: Arbitrary[B ~> A],
+    arbFkCB: Arbitrary[C ~> B],
+    eqFa: Eq[F[A]],
+    eqFc: Eq[F[C]]
+  ): RuleSet = new DefaultRuleSet(
+    name = "contravariantK",
+    parent = Some(invariantK[A, B, C]),
+    "contravariant identity" -> forAll(laws.contravariantIdentity[A] _),
+    "contravariant composition" -> forAll(laws.contravariantComposition[A, B, C] _)
+  )
+}
+
+object ContravariantKTests {
+  def apply[F[_[_]]: ContravariantK]: ContravariantKTests[F] =
+    new ContravariantKTests[F] { val laws = ContravariantKLaws[F] }
+}

--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -51,6 +51,7 @@ object Derive {
    */
   def functorK[Alg[_[_]]]: FunctorK[Alg] = macro DeriveMacros.functorK[Alg]
 
+  def contravariantK[Alg[_[_]]]: ContravariantK[Alg] = macro DeriveMacros.contravariantK[Alg]
   def invariantK[Alg[_[_]]]: InvariantK[Alg] = macro DeriveMacros.invariantK[Alg]
   def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = macro DeriveMacros.semigroupalK[Alg]
   def applyK[Alg[_[_]]]: ApplyK[Alg] = macro DeriveMacros.applyK[Alg]

--- a/macros/src/main/scala/cats/tagless/autoContravariantK.scala
+++ b/macros/src/main/scala/cats/tagless/autoContravariantK.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
+import scala.reflect.macros.whitebox
+
+/** Auto generates an instance of [[ContravariantK]]. */
+@compileTimeOnly("Cannot expand @autoFunctorK")
+class autoContravariantK(autoDerivation: Boolean = true) extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoContravariantKMacros.contravariantKInst
+}
+
+private [tagless] class autoContravariantKMacros(override val c: whitebox.Context) extends MacroUtils {
+  import c.universe._
+
+  private def generateContravariantKFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("contravariantKFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.tagless.ContravariantK[$algebraType]",
+      q"_root_.cats.tagless.Derive.contravariantK[$algebraType]"
+    )
+
+  def contravariantKInst(annottees: c.Tree*): c.Tree =
+    enrichAlgebra(annottees.toList) { algebra =>
+      algebra.forVaryingEffectType(generateContravariantKFor(algebra.name)) :: Nil
+    }
+}

--- a/tests/src/test/scala/cats/tagless/tests/CatsDataInstancesTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/CatsDataInstancesTests.scala
@@ -22,7 +22,7 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.tagless.IdK
 import cats.tagless.laws.discipline.SemigroupalKTests.IsomorphismsK
-import cats.tagless.laws.discipline.{ApplyKTests, FunctorKTests}
+import cats.tagless.laws.discipline.{ApplyKTests, ContravariantKTests, FunctorKTests}
 
 import scala.util.Try
 
@@ -32,6 +32,7 @@ class CatsDataInstancesTests extends CatsTaglessTestSuite {
   checkAll("FunctorK[Nested[?[_], Eval, Int]]", FunctorKTests[Nested[?[_], Eval, Int]].functorK[Try, Option, List, Int])
   checkAll("FunctorK[OneAnd[?[_], Boolean]]", FunctorKTests[OneAnd[?[_], Boolean]].functorK[Try, Option, List, Int])
   checkAll("FunctorK[Tuple2K[Eval, ?[_], Int]]", FunctorKTests[Tuple2K[Eval, ?[_], Int]].functorK[Try, Option, List, Int])
+  checkAll("ContravariantK[Cokleisli[?[_], String, Int]]", ContravariantKTests[Cokleisli[?[_], String, Int]].contravariantK[Try, Option, List, Int])
   checkAll("ApplyK[IdK[Int]#λ]", ApplyKTests[IdK[Int]#λ].applyK[Try, Option, List, Int])
   checkAll("ApplyK[EitherK[Eval, ?[_], Int]]", ApplyKTests[EitherK[Eval, ?[_], Int]].applyK[Try, Option, List, Int])
   checkAll("ApplyK[EitherT[?[_], String, Int]]", ApplyKTests[EitherT[?[_], String, Int]].applyK[Try, Option, List, Int])

--- a/tests/src/test/scala/cats/tagless/tests/CatsTaglessTestSuite.scala
+++ b/tests/src/test/scala/cats/tagless/tests/CatsTaglessTestSuite.scala
@@ -64,6 +64,9 @@ trait TestInstances {
   implicit def catsTaglessLawsEqForKleisli[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by(_.run)
 
+  implicit def catsTaglessLawsEqForCokleisli[F[_], A, B](implicit ev: Eq[F[A] => B]): Eq[Cokleisli[F, A, B]] =
+    Eq.by(_.run)
+
   //------------------------------------------------------------------
   // The instances below are needed due to type inference limitations:
   //------------------------------------------------------------------
@@ -107,6 +110,10 @@ trait TestInstances {
   implicit def catsTaglessLawsEqForKleisliTuple3K[F[_], G[_], H[_], A, B](
     implicit ev: Eq[A => (F[B], G[B], H[B])]
   ): Eq[Kleisli[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.run)
+
+  implicit def catsTaglessLawsEqForCokleisliTuple3K[F[_], G[_], H[_], A, B](
+    implicit ev: Eq[((F[A], G[A], H[A])) => B]
+  ): Eq[Cokleisli[Tuple3K[F, G, H]#λ, A, B]] = Eq.by(_.run)
 
   implicit def catsTaglessLawsEqForOneAndTuple3K[F[_], G[_], H[_], A](
     implicit ev: Eq[(A, (F[A], G[A], H[A]))]

--- a/tests/src/test/scala/cats/tagless/tests/autoContravariantKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoContravariantKTests.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+
+import cats.Eq
+import cats.data.Cokleisli
+import cats.instances.all._
+import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.tagless.{ContravariantK, autoContravariantK}
+import cats.tagless.instances.all._
+import cats.tagless.laws.discipline.ContravariantKTests
+import org.scalacheck.{Arbitrary, Cogen}
+
+import scala.util.Try
+
+class autoContravariantKTests extends CatsTaglessTestSuite {
+  import autoContravariantKTests._
+
+  checkAll("ContravariantK[TestAlgebra]", ContravariantKTests[TestAlgebra].contravariantK[Try, Option, List, Int])
+  checkAll("Serializable ContravariantK[TestAlgebra]", SerializableTests.serializable(ContravariantK[TestAlgebra]))
+}
+
+object autoContravariantKTests {
+  import TestInstances._
+
+  @autoContravariantK
+  trait TestAlgebra[F[_]] {
+    def sum(xs: F[Int]): Int
+    def sumAll(xss: F[Int]*): Int
+    def foldSpecialized(init: String)(f: (Int, String) => Int): Cokleisli[F, String, Int]
+  }
+
+  object TestAlgebra {
+    implicit def eqv[F[_]](implicit arbFi: Arbitrary[F[Int]], arbFs: Arbitrary[F[String]]): Eq[TestAlgebra[F]] =
+      Eq.by { algebra => (algebra.sum _, algebra.sumAll _, algebra.foldSpecialized _) }
+  }
+
+  implicit def arbitrary[F[_]](
+    implicit arbFs: Arbitrary[F[String]], coFi: Cogen[F[Int]], coFs: Cogen[F[String]]
+  ): Arbitrary[TestAlgebra[F]] = Arbitrary(for {
+    s <- Arbitrary.arbitrary[F[Int] => Int]
+    sa <- Arbitrary.arbitrary[Seq[F[Int]] => Int]
+    fs <- Arbitrary.arbitrary[(String, (Int, String) => Int) => Cokleisli[F, String, Int]]
+  } yield new TestAlgebra[F] {
+    def sum(xs: F[Int]) = s(xs)
+    def sumAll(xss: F[Int]*) = sa(xss)
+    def foldSpecialized(init: String)(f: (Int, String) => Int) = fs(init, f)
+  })
+
+  @autoContravariantK
+  trait TestAlgebraWithExtraTypeParam[F[_], A] extends TestAlgebra[F] {
+    def fold[B](init: B)(f: (B, A) => B): Cokleisli[F, A, B]
+  }
+}


### PR DESCRIPTION
The `ContravariantK` typeclass is a higher-kinded `Contravariant`.
  * `FunctorK` derivation utilizes `ContravariantK` in argument position.
  * Add instance of `ContravariantK[Cokleisli[?[_], A, B]]`
  * Add `autoContravariantK` macro annotation

For now didn't bother with a fully refined instance
and companion methods.

Closes #58 