### PR TITLE
Instrument

### DIFF
--- a/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
+++ b/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
@@ -18,7 +18,6 @@ package cats.tagless.diagnosis
 
 import simulacrum.typeclass
 
-
 final case class Instrumentation[F[_], A](
   value: F[A],
   algebraName: String,

--- a/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
+++ b/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.diagnosis
+
+import simulacrum.typeclass
+
+final case class Instrumentation[F[_], A](
+  value: F[A],
+  algebraName: String,
+  methodName: String
+)
+
+@typeclass
+trait Instrument[Alg[_[_]]] {
+  def instrument[F[_]](af: Alg[F]): Alg[Instrumentation[F, *]]
+}

--- a/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
+++ b/core/src/main/scala/cats/tagless/diagnosis/Instrument.scala
@@ -18,12 +18,18 @@ package cats.tagless.diagnosis
 
 import simulacrum.typeclass
 
+
 final case class Instrumentation[F[_], A](
   value: F[A],
   algebraName: String,
   methodName: String
 )
 
+/**
+  * Type classes for instrumenting algebras.
+  * This feature is experimental, API is likely to change.
+  * @tparam Alg The algebra type you want to instrument.
+  */
 @typeclass
 trait Instrument[Alg[_[_]]] {
   def instrument[F[_]](af: Alg[F]): Alg[Instrumentation[F, *]]

--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -58,5 +58,12 @@ object Derive {
   def invariantK[Alg[_[_]]]: InvariantK[Alg] = macro DeriveMacros.invariantK[Alg]
   def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = macro DeriveMacros.semigroupalK[Alg]
   def applyK[Alg[_[_]]]: ApplyK[Alg] = macro DeriveMacros.applyK[Alg]
+
+  /**
+    * Type classes for instrumenting algebras.
+    * This feature is experimental, API is likely to change.
+    * @tparam Alg The algebra type you want to instrument.
+    * @return An instrumented algebra.
+    */
   def instrument[Alg[_[_]]]: Instrument[Alg] = macro DeriveMacros.instrument[Alg]
 }

--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -17,6 +17,7 @@
 package cats.tagless
 
 import cats.arrow.Profunctor
+import cats.tagless.diagnosis.Instrument
 import cats.{Apply, Bifunctor, Contravariant, FlatMap, Functor, Invariant, Semigroupal}
 
 object Derive {
@@ -57,4 +58,5 @@ object Derive {
   def invariantK[Alg[_[_]]]: InvariantK[Alg] = macro DeriveMacros.invariantK[Alg]
   def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = macro DeriveMacros.semigroupalK[Alg]
   def applyK[Alg[_[_]]]: ApplyK[Alg] = macro DeriveMacros.applyK[Alg]
+  def instrument[Alg[_[_]]]: Instrument[Alg] = macro DeriveMacros.instrument[Alg]
 }

--- a/macros/src/main/scala/cats/tagless/autoInstrument.scala
+++ b/macros/src/main/scala/cats/tagless/autoInstrument.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
+import scala.reflect.macros.whitebox
+
+/** Auto generates an instance of `cats.Invariant`. */
+@compileTimeOnly("Cannot expand @autoInstrument")
+class autoInstrument extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoInstrumentMacros.instrumentInst
+}
+
+private[tagless] class autoInstrumentMacros(override val c: whitebox.Context) extends MacroUtils  {
+  import c.universe._
+
+  private def generateInstrumentFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("instrumentFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.tagless.diagnosis.Instrument[$algebraType]",
+      q"_root_.cats.tagless.Derive.instrument[$algebraType]"
+    )
+
+  def instrumentInst(annottees: c.Tree*): c.Tree =
+    enrichAlgebra(annottees.toList, AlgebraResolver.FirstHigherKindedTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateInstrumentFor(algebra.name)) :: Nil
+    }
+}

--- a/tests/src/test/scala/cats/tagless/tests/InstrumentTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/InstrumentTests.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+
+import cats.Id
+import cats.tagless.{Derive, autoInstrument, finalAlg}
+import InstrumentTests._
+import cats.tagless.diagnosis.Instrument
+
+class InstrumentTests extends CatsTaglessTestSuite {
+
+  test("Instrument should put method and algebra name in result") {
+    val dummy = new KVStore[Id] {
+      def get(key: String): Id[Option[String]] = Some(s"Test $key")
+      def put(key: String, a: String): Id[Unit] = ()
+    }
+    val instrumented = Derive.instrument[KVStore].instrument(dummy)
+
+    val res = instrumented.get("key1")
+
+    res.algebraName shouldBe "KVStore"
+    res.methodName shouldBe "get"
+    res.value shouldBe Some("Test key1")
+
+  }
+
+  test("autoInstrument annotation") {
+    val dummy = new Lookup[Id] {
+      def ->(id: String): Id[Option[Long]] = Some(1)
+    }
+
+    val instrumented = Instrument[Lookup].instrument(dummy)
+
+    val res = instrumented.->("key1")
+
+    res.algebraName shouldBe "Lookup"
+    res.methodName shouldBe "->"
+    res.value shouldBe Some(1)
+  }
+
+}
+
+object InstrumentTests {
+  @autoInstrument
+  @finalAlg
+  trait Lookup[F[_]] {
+    def ->(id: String): F[Option[Long]]
+  }
+}


### PR DESCRIPTION
As discussed with @joroKr21 on gitter.

It would be nice to have a typeclass `DescribeK` which includes the method name (and class name) for all the algebra methods plus the resulting computation. This can be used by tracing or metrics.

Pseudo example code:

```scala
trait OffsetStore[F[_]] {
  def get(name: String): F[Option[Long]]
  def set(name: String, eventId: Long): F[Int]
}

val dummy = new OffsetStore[RIO[Tracing, *]] {
  def get(name: String): RIO[Tracing, Option[Long]] = ZIO.succeed(Some(2l))
  def set(name: String, eventId: Long): RIO[Tracing, [Int] = ZIO.succeed(1)
}

val describeK = Derive.describe[OffsetStore]
val functorK = Derive.functorK[OffsetStore]

// transform the describeK algebra using a natural transformation which uses `RIO[Tracing, *]` and the method `String` 
// to create a OpenTracing span by using `.instrumented`
val tracing = new (Lambda[A => (RIO[Tracing, A], String)] ~> RIO[Tracing, *]) {
    def apply[A](fa: (RIO[Tracing, A], String)): RIO[Tracing, A] =
      fa._1.instrumented(fa._2)
  }

//instrumented algebra
val instrumented = functorK.mapK(describeK)(tracing)
```

The algebra plus macro is there, but the only thing I'm stuck at is how to create a type lambda in macro code? Maybe someone could jump in and help :) 

See:

```
Error:(14, 31) exception during macro expansion: 
scala.reflect.macros.TypecheckException: type mismatch;
 found   : OffsetStore[F$macro$2]
 required: OffsetStore[[A](F$macro$2[A], String)]
```

As you can see, the required type does match up with the given (which was `f`)

Also we need some tests.