### PR TITLE
Semigroupal derivation

### DIFF
--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -17,7 +17,7 @@
 package cats.tagless
 
 import cats.arrow.Profunctor
-import cats.{Apply, Bifunctor, Contravariant, FlatMap, Functor, Invariant}
+import cats.{Apply, Bifunctor, Contravariant, FlatMap, Functor, Invariant, Semigroupal}
 
 object Derive {
 
@@ -26,6 +26,7 @@ object Derive {
   def invariant[F[_]]: Invariant[F] = macro DeriveMacros.invariant[F]
   def profunctor[F[_, _]]: Profunctor[F] = macro DeriveMacros.profunctor[F]
   def bifunctor[F[_, _]]: Bifunctor[F] = macro DeriveMacros.bifunctor[F]
+  def semigroupal[F[_]]: Semigroupal[F] = macro DeriveMacros.semigroupal[F]
   def apply[F[_]]: Apply[F] = macro DeriveMacros.apply[F]
   def flatMap[F[_]]: FlatMap[F] = macro DeriveMacros.flatMap[F]
 

--- a/macros/src/main/scala/cats/tagless/autoSemigroupal.scala
+++ b/macros/src/main/scala/cats/tagless/autoSemigroupal.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
+import scala.reflect.macros.whitebox
+
+/** Auto generates an instance of `cats.Semigroupal`. */
+@compileTimeOnly("Cannot expand @autoSemigroupal")
+class autoSemigroupal extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoSemigroupalMacros.semigroupalInst
+}
+
+
+private[tagless] class autoSemigroupalMacros(override val c: whitebox.Context) extends MacroUtils {
+  import c.universe._
+
+  private def generateSemigroupalFor(algebraName: String)(algebraType: Tree, typeParams: Seq[TypeDef]) =
+    typeClassInstance(
+      TermName("semigroupalFor" + algebraName),
+      typeParams,
+      tq"_root_.cats.Semigroupal[$algebraType]",
+      q"_root_.cats.tagless.Derive.semigroupal[$algebraType]"
+    )
+
+  def semigroupalInst(annottees: c.Tree*): c.Tree =
+    enrichAlgebra(annottees.toList, AlgebraResolver.LastRegularTypeParam) { algebra =>
+      algebra.forVaryingEffectType(generateSemigroupalFor(algebra.name)) :: Nil
+    }
+}

--- a/tests/src/test/scala/cats/tagless/tests/autoSemigroupalTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoSemigroupalTests.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+
+import cats.instances.all._
+import cats.laws.discipline.eq._
+import cats.laws.discipline.{SemigroupalTests, SerializableTests}
+import cats.tagless.{autoInvariant, autoSemigroupal}
+import cats.{Eq, Semigroupal}
+import org.scalacheck.Arbitrary
+
+class autoSemigroupalTests extends CatsTaglessTestSuite {
+  import autoSemigroupalTests._
+
+  checkAll("Semigroupal[TestAlgebra]", SemigroupalTests[TestAlgebra].semigroupal[Long, String, Int])
+  checkAll("Serializable Semigroupal[TestAlgebra]", SerializableTests.serializable(Semigroupal[TestAlgebra]))
+}
+
+object autoSemigroupalTests {
+  import TestInstances._
+
+  @autoSemigroupal
+  @autoInvariant // Needed for Isomorphisms
+  trait TestAlgebra[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def curried(a: String)(b: Int): T
+  }
+
+  @autoSemigroupal
+  trait AlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1): T
+  }
+
+  @autoSemigroupal
+  trait AlgWithGenericMethod[T] {
+    def plusOne[A](i: A): T
+  }
+
+  @autoSemigroupal
+  trait AlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def product(xs: Int*): T
+  }
+
+  implicit def eqForTestAlgebra[T: Eq]: Eq[TestAlgebra[T]] =
+    Eq.by { algebra =>
+      (
+        algebra.abstractEffect _,
+        algebra.concreteEffect _,
+        algebra.abstractOther _,
+        algebra.concreteOther _,
+        algebra.withoutParams,
+        Function.uncurried(algebra.curried _).tupled
+      )
+    }
+
+  implicit def arbitraryTestAlgebra[T: Arbitrary]: Arbitrary[TestAlgebra[T]] =
+    Arbitrary {
+      for {
+        absEff <- Arbitrary.arbitrary[String => T]
+        conEff <- Arbitrary.arbitrary[Option[String => T]]
+        absOther <- Arbitrary.arbitrary[String => String]
+        conOther <- Arbitrary.arbitrary[Option[String => String]]
+        withoutParameters <- Arbitrary.arbitrary[T]
+        curry <- Arbitrary.arbitrary[String => Int => T]
+      } yield new TestAlgebra[T] {
+        override def abstractEffect(i: String) = absEff(i)
+        override def concreteEffect(a: String) = conEff.getOrElse(super.concreteEffect(_))(a)
+        override def abstractOther(a: String) = absOther(a)
+        override def concreteOther(a: String) = conOther.getOrElse(super.concreteOther(_))(a)
+        override def withoutParams = withoutParameters
+        override def curried(a: String)(b: Int) = curry(a)(b)
+      }
+    }
+}
+


### PR DESCRIPTION
Similar to `Apply` and `SemigroupalK` derivation.
Still useful because it relies only on `Semigroupal` instances,
whereas `Apply` relies on `Apply` instances of return types.

Closes #51 