### PR TITLE
NihilistK: create something ex nihilo, from an EmptyK

### DIFF
--- a/core/src/main/scala/cats/tagless/NihilistK.scala
+++ b/core/src/main/scala/cats/tagless/NihilistK.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import simulacrum.typeclass
+import alleycats.EmptyK
+
+/**
+ * Given an EmptyK, a value-polymorphic but effect-constant constructor, 
+ * we can build an instance of the handler that, on every operation, gives us that. 
+**/ 
+@typeclass
+trait NihilistK[A[_[_]]] {
+  def exNihiloK[F[_]](emptyK: EmptyK[F]): A[F]
+}

--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -54,6 +54,9 @@ object Derive {
    */
   def functorK[Alg[_[_]]]: FunctorK[Alg] = macro DeriveMacros.functorK[Alg]
 
+  /** Generates a NihilistK instance */
+  def nihilistK[Alg[_[_]]]: NihilistK[Alg] = macro DeriveMacros.nihilistK[Alg]
+
   def contravariantK[Alg[_[_]]]: ContravariantK[Alg] = macro DeriveMacros.contravariantK[Alg]
   def invariantK[Alg[_[_]]]: InvariantK[Alg] = macro DeriveMacros.invariantK[Alg]
   def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = macro DeriveMacros.semigroupalK[Alg]

--- a/macros/src/main/scala/cats/tagless/DeriveMacros.scala
+++ b/macros/src/main/scala/cats/tagless/DeriveMacros.scala
@@ -246,6 +246,20 @@ class DeriveMacros(val c: blackbox.Context) {
       implement(algebra)(b)(types ++ methods)
     }
 
+  // def exNihiloK[F[_]](ek: EmptyK[F]): A[F]
+  def exNihiloK(algebra: Type): (String, Type => Tree) =
+    "exNihiloK" -> { case PolyType(List(f), MethodType(List(ek), _) ) => 
+      val Af = singleType(NoPrefix, af)
+      val members = overridableMembersOf(Af)
+      val types = delegateAbstractTypes(Af, members, Af)
+      val methods = ???
+      // So... we are not going to delegate methods, because we are building from zero.
+      // WE need to create, for each method `def fili($..paramss): F[A]`, a body of the form:
+      // def fili($..paramss): F[A] = ek.empty[A]`
+      // so, ta
+      implement(algebra)(b)(types ++ methods)
+    }
+
   // def mapK[F[_], G[_]](af: A[F])(fk: F ~> G): A[G]
   def mapK(algebra: Type): (String, Type => Tree) =
     "mapK" -> { case PolyType(List(f, g), MethodType(List(af), MethodType(List(fk), _))) =>
@@ -591,6 +605,9 @@ class DeriveMacros(val c: blackbox.Context) {
 
   def functorK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
     instantiate[FunctorK[Alg]](tag)(mapK)
+
+  def functorK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
+    instantiate[NihilistK[Alg]](tag)(exNihilK)
 
   def contravariantK[Alg[_[_]]](implicit tag: WeakTypeTag[Alg[Any]]): Tree =
     instantiate[ContravariantK[Alg]](tag)(contramapK)

--- a/macros/src/main/scala/cats/tagless/autoNihilistK.scala
+++ b/macros/src/main/scala/cats/tagless/autoNihilistK.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.collection.immutable.Seq
+import scala.reflect.macros.whitebox
+
+/** Auto generates an instance of [[cats.tagless.NihilistK]]. */
+@compileTimeOnly("Cannot expand @autoInstrument")
+class autoNihilistK extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro autoNihilistMacros.nihilistInst
+}
+
+private[tagless] class autoNihilistMacros(override val c: whitebox.Context) extends MacroUtils  {
+  import c.universe._
+
+  def nihilist(annottees: c.Tree*): c.Tree = ??? // TODO.
+
+}


### PR DESCRIPTION
DONOTMERGE For some use cases, we may want to create an instance for an Algebra, using an `alleycats.EmptyK`. Essentially, a effectful operation with no values of the inner return type.


#### Example

Given the following algebra: 
```Scala
trait Dwarves[F[_]] { 
  def fili(x: Int): F[Unit]
  def kili(y: Char): F[Boolean] 
}
```

I would like to generate a class that implements that algebra, using in every operation the `empty` operation of the given `EmptyK`:

```Scala
class EmptyDwarves[G[_]](ek: EmptyK[G]) extends Dwarves[G] {
  def fili(x: Int): G[Unit] = ek.empty[Unit]
  def kili(y: Char): G[Boolean] = ek.empty[Boolean]
}
```

The primary use case I am looking for is for testing, to do something similar to what mocks do: I would like to generate an instance of an algebra that, by default, would generate an error in every operation. I would then be able to override any method I wish to implement in each test...

```Scala
import cats.effect.IO

val mockDwarves: EmptyDwarves[IO] = new EmptyDwarves {
  override def fili(x: Int): IO[Unit] = IO.unit
}
```


