### PR TITLE
Fix byname parameters when they have to be transformed

### DIFF
--- a/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/autoInvariantKTests.scala
@@ -197,4 +197,9 @@ object autoInvariantKTests {
     def contravariantSum(xs: F[Int]*): Int
     def invariantSum(xs: F[Int]*): F[Int]
   }
+
+  @autoInvariantK
+  trait AlgWithByNameParameter[F[_]] {
+    def whenM(cond: F[Boolean])(action: => F[Unit]): F[Unit]
+  }
 }


### PR DESCRIPTION
Also add method name to error message when required implicit is missing.

Fixes #133 