### PR TITLE
Update Catalyst and Cats, drop Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ git:
 jdk:
   - oraclejdk8
 
-scala_version_211: &scala_version_211 2.11.12
 scala_version_212: &scala_version_212 2.12.11
 scala_version_213: &scala_version_213 2.13.1
 
@@ -29,13 +28,11 @@ jobs:
     # it can speed up the overall build to have the longer-running jobs at the top of this list.
     - env: TEST="coverage"
       install: pip install --user codecov
-      script: sbt coverage rootJVM/test coverageReport && codecov
+      script: sbt coverage rootJVM/test rootJVM/coverageReport && codecov
 
     - &js_tests
       env: TEST="JS tests"
       script: sbt ";project rootJS;++$TRAVIS_SCALA_VERSION test"
-      scala: *scala_version_211
-    - <<: *js_tests
       scala: *scala_version_212
     - <<: *js_tests
       scala: *scala_version_213
@@ -43,8 +40,6 @@ jobs:
     - &jvm_tests
       env: TEST="JVM tests"
       script: sbt ";project rootJVM; ++$TRAVIS_SCALA_VERSION test"
-      scala: *scala_version_211
-    - <<: *jvm_tests
       scala: *scala_version_212
     - <<: *jvm_tests
       scala: *scala_version_213

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cats-tagless is a small library built to facilitate transforming and composing t
 
 ## Installation
 
-Cats-tagless is currently available for Scala 2.11, 2.12 and 2.13. 
+Cats-tagless is currently available for Scala 2.12 and 2.13 and Scala.js.
 
 Add the following settings in `build.sbt`
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,14 @@ addCommandAlias("validateJVM", ";testsJVM/test ; docs/makeMicrosite")
 lazy val libs = org.typelevel.libraries
   .add("scalatestplus", version = "3.1.1.1", org = "org.scalatestplus", "scalacheck-1-14")
   .add("discipline-scalatest", version = "1.0.1", org = org.typelevel.typeLevelOrg)
-  .add("cats", version = "2.0.0")
+  .add("cats", version = "2.1.1")
   .add("paradise", version = "2.1.1")
 
 val apache2 = "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")
 val gh = GitHubSettings(org = "typelevel", proj = "cats-tagless", publishOrg = "org.typelevel", license = apache2)
 
 
-lazy val rootSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings
+lazy val rootSettings = buildSettings ++ commonSettings ++ publishSettings
 lazy val module = mkModuleFactory(gh.proj, mkConfig(rootSettings, commonJvmSettings, commonJsSettings))
 lazy val prj = mkPrjFactory(rootSettings)
 
@@ -23,29 +23,19 @@ lazy val rootPrj = project
   .configure(mkRootConfig(rootSettings,rootJVM))
   .aggregate(rootJVM, rootJS, docs)
   .dependsOn(rootJVM, rootJS)
-  .settings(
-    noPublishSettings,
-    crossScalaVersions := Nil
-  )
-
+  .settings(noPublishSettings, crossScalaVersions := Nil)
 
 lazy val rootJVM = project
   .configure(mkRootJvmConfig(gh.proj, rootSettings, commonJvmSettings))
   .aggregate(coreJVM, lawsJVM, testsJVM, macrosJVM)
   .dependsOn(coreJVM, lawsJVM, testsJVM, macrosJVM)
-  .settings(noPublishSettings,
-    crossScalaVersions := Nil)
-
+  .settings(noPublishSettings, crossScalaVersions := Nil)
 
 lazy val rootJS = project
   .configure(mkRootJsConfig(gh.proj, rootSettings, commonJsSettings))
   .aggregate(coreJS, lawsJS, testsJS, macrosJS)
   .dependsOn(coreJS, lawsJS, testsJS, macrosJS)
-  .settings(
-    noPublishSettings,
-    crossScalaVersions := Nil
-  )
-
+  .settings(noPublishSettings, crossScalaVersions := Nil)
 
 lazy val core    = prj(coreM)
 lazy val coreJVM = coreM.jvm
@@ -111,7 +101,7 @@ lazy val docs = project
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(SiteScaladocPlugin)
   .settings(
-    crossScalaVersions := crossScalaVersions.value.filterNot(_ == libs.vers("scalac_2.13")),
+    crossScalaVersions -= libs.vers("scalac_2.13"),
     docsMappingsAPIDir := "api",
     addMappingsToSiteDir(mappings in packageDoc in Compile in coreJVM, docsMappingsAPIDir),
     organization  := gh.organisation,
@@ -146,7 +136,7 @@ lazy val buildSettings = sharedBuildSettings(gh, libs)
 lazy val commonSettings = sharedCommonSettings ++ Seq(
   parallelExecution in Test := false,
   scalaVersion := libs.vers("scalac_2.12"),
-  crossScalaVersions := Seq(libs.vers("scalac_2.11"), scalaVersion.value, libs.vers("scalac_2.13")),
+  crossScalaVersions := Seq(scalaVersion.value, libs.vers("scalac_2.13")),
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
   addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
   developers := List(
@@ -162,7 +152,7 @@ lazy val commonJsSettings = Seq(
   doctestGenTests := Seq.empty
 )
 
-lazy val commonJvmSettings = Seq()
+lazy val commonJvmSettings = scoverageSettings
 
 lazy val publishSettings = sharedPublishSettings(gh) ++ credentialSettings ++ sharedReleaseProcess
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -17,7 +17,7 @@ Cats-tagless is a small library built to facilitate composing tagless final enco
 
 ## Installation
 
-Cats-tagless is available on scala 2.11, 2.12, 2.13 and scalajs. 
+Cats-tagless is available on scala 2.12, 2.13 and Scala.js. 
 Add the following dependency in `build.sbt`
 
 ```scala

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("org.typelevel" %% "sbt-catalysts" % "0.36")
-
+addSbtPlugin("org.typelevel" %% "sbt-catalysts" % "0.38")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.6")


### PR DESCRIPTION
This updates to Scala.js 1.0.

Closes #139 
Closes #138 