### PR TITLE
Bring back algebraName at Instrumentation and add it to Aspect

### DIFF
--- a/core/src/main/scala/cats/tagless/aop/Aspect.scala
+++ b/core/src/main/scala/cats/tagless/aop/Aspect.scala
@@ -53,13 +53,14 @@ object Aspect {
     * @tparam A Return type of the method.
     */
   final case class Weave[F[_], Dom[_], Cod[_], A](
+    algebraName: String,
     domain: List[List[Advice[Eval, Dom]]],
     codomain: Advice.Aux[F, Cod, A]
   ) {
 
     /** Convert this [[Weave]] to an [[Instrumentation]], throwing away information about the `domain`. */
     def instrumentation: Instrumentation[F, A] =
-      Instrumentation(codomain.target, codomain.algebraName, codomain.methodName)
+      Instrumentation(codomain.target, algebraName, codomain.name)
   }
 
   object Weave {
@@ -77,29 +78,27 @@ object Aspect {
     */
   trait Advice[F[_], G[_]] extends Serializable {
     type A
-    def methodName: String
-    def algebraName: String
+    def name: String
     def target: F[A]
     implicit def instance: G[A]
-    override def toString: String = s"$methodName: $target"
+    override def toString: String = s"$name: $target"
   }
 
   object Advice {
     type Aux[F[_], G[_], T] = Advice[F, G] { type A = T }
 
-    def apply[F[_], G[_], T](algebra: String, method: String, adviceTarget: F[T])(implicit G: G[T]): Aux[F, G, T] =
+    def apply[F[_], G[_], T](method: String, adviceTarget: F[T])(implicit G: G[T]): Aux[F, G, T] =
       new Advice[F, G] {
         type A = T
-        val methodName = method
-        val algebraName = algebra
+        val name = method
         val target = adviceTarget
         val instance = G
       }
 
-    def byValue[G[_], T: G](algebra: String, method: String, value: T): Aux[Eval, G, T] =
-      Advice(algebra, method, Eval.now(value))
+    def byValue[G[_], T: G](name: String, value: T): Aux[Eval, G, T] =
+      Advice(name, Eval.now(value))
 
-    def byName[G[_], T: G](algebra: String, method: String, thunk: => T): Aux[Eval, G, T] =
-      Advice(algebra, method, Eval.always(thunk))
+    def byName[G[_], T: G](name: String, thunk: => T): Aux[Eval, G, T] =
+      Advice(name, Eval.always(thunk))
   }
 }

--- a/core/src/main/scala/cats/tagless/aop/Aspect.scala
+++ b/core/src/main/scala/cats/tagless/aop/Aspect.scala
@@ -87,10 +87,10 @@ object Aspect {
   object Advice {
     type Aux[F[_], G[_], T] = Advice[F, G] { type A = T }
 
-    def apply[F[_], G[_], T](method: String, adviceTarget: F[T])(implicit G: G[T]): Aux[F, G, T] =
+    def apply[F[_], G[_], T](adviceName: String, adviceTarget: F[T])(implicit G: G[T]): Aux[F, G, T] =
       new Advice[F, G] {
         type A = T
-        val name = method
+        val name = adviceName
         val target = adviceTarget
         val instance = G
       }

--- a/core/src/main/scala/cats/tagless/aop/Instrument.scala
+++ b/core/src/main/scala/cats/tagless/aop/Instrument.scala
@@ -20,7 +20,7 @@ import cats.tagless.FunctorK
 import simulacrum.typeclass
 
 /** The result of an algebra method `F[A]` instrumented with the method name. */
-final case class Instrumentation[F[_], A](value: F[A], methodName: String)
+final case class Instrumentation[F[_], A](value: F[A], algebraName: String, methodName: String)
 
 /** Type class for instrumenting an algebra.
   * Note: This feature is experimental, API is likely to change.
@@ -29,6 +29,5 @@ final case class Instrumentation[F[_], A](value: F[A], methodName: String)
   */
 @typeclass
 trait Instrument[Alg[_[_]]] extends FunctorK[Alg] {
-  def algebraName: String
   def instrument[F[_]](af: Alg[F]): Alg[Instrumentation[F, *]]
 }

--- a/macros/src/main/scala/cats/tagless/DeriveMacros.scala
+++ b/macros/src/main/scala/cats/tagless/DeriveMacros.scala
@@ -599,14 +599,14 @@ class DeriveMacros(val c: blackbox.Context) {
           val AspectAdvice = reify(Aspect.Advice)
           val arguments = method.transformedArgLists { case param @ Parameter(pn, pt, pm) =>
             val constructor = TermName(if (pm.hasFlag(Flag.BYNAMEPARAM)) "byName" else "byValue")
-            q"$AspectAdvice.$constructor[$Dom, $pt]($algebraName, ${param.displayName}, $pn)"
+            q"$AspectAdvice.$constructor[$Dom, $pt](${param.displayName}, $pn)"
           }
 
           val hasImplicits = method.signature.paramLists.lastOption.flatMap(_.headOption).exists(_.isImplicit)
           val domain = if (hasImplicits) arguments.dropRight(1) else arguments
           val typeArgs = method.returnType.typeArgs
-          val codomain = q"$AspectAdvice[$F, $Cod, ..$typeArgs]($algebraName, ${method.displayName}, ${method.body})"
-          val body = q"${reify(Aspect.Weave)}[$F, $Dom, $Cod, ..$typeArgs]($domain, $codomain)"
+          val codomain = q"$AspectAdvice[$F, $Cod, ..$typeArgs](${method.displayName}, ${method.body})"
+          val body = q"${reify(Aspect.Weave)}[$F, $Dom, $Cod, ..$typeArgs]($algebraName, $domain, $codomain)"
           val returnType = appliedType(AspectWeave, F :: Dom :: Cod :: typeArgs)
           method.copy(body = body, returnType = returnType)
         case method if method.occursInSignature(f) =>

--- a/tests/src/test/scala/cats/tagless/tests/AspectTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/AspectTests.scala
@@ -36,29 +36,32 @@ class AspectTests extends CatsTaglessTestSuite {
     }
 
     def testWeave[A](weave: Aspect.Weave.Function[List, Show, A])(
+      algebraName: String,
       domain: List[Map[String, String]],
       codomainName: String,
       codomainTarget: List[String]
     ): Assertion = {
-      weave.domain.map(_.map(a => a.name -> a.instance.show(a.target.value)).toMap) shouldBe domain
-      weave.codomain.name shouldBe codomainName
+      weave.domain.map(_.map(a => a.methodName -> a.instance.show(a.target.value)).toMap) shouldBe domain
+      weave.codomain.algebraName shouldBe algebraName
+      weave.codomain.methodName shouldBe codomainName
       weave.codomain.target.map(weave.codomain.instance.show) shouldBe codomainTarget
     }
 
     val weaved = algebra.weaveFunction[Show]
-    testWeave(weaved.showF(42))(List(Map("a" -> "42")), "showF", List("42"))
+    testWeave(weaved.showF(42))("ShowFAlgebra", List(Map("a" -> "42")), "showF", List("42"))
     testWeave(weaved.showAll("foo", "bar", "baz"))(
+      "ShowFAlgebra",
       List(Map("as" -> "foo", "as" -> "bar", "as" -> "baz")),
       "showAll",
       List("foo", "bar", "baz")
     )
 
-    testWeave(weaved.showProduct(3.14))(List(Map("a" -> "3.14")), "showProduct", List("(3.14,3.14)"))
+    testWeave(weaved.showProduct(3.14))("ShowFAlgebra", List(Map("a" -> "3.14")), "showProduct", List("(3.14,3.14)"))
     val it = (1 to 3).iterator
     val logF = weaved.logF(it.next().toString)
-    testWeave(logF)(List(Map("message" -> "1")), "logF", Nil)
-    testWeave(logF)(List(Map("message" -> "2")), "logF", Nil)
-    testWeave(logF)(List(Map("message" -> "3")), "logF", Nil)
+    testWeave(logF)("ShowFAlgebra", List(Map("message" -> "1")), "logF", Nil)
+    testWeave(logF)("ShowFAlgebra", List(Map("message" -> "2")), "logF", Nil)
+    testWeave(logF)("ShowFAlgebra", List(Map("message" -> "3")), "logF", Nil)
   }
 
   test("Json aspect") {
@@ -67,11 +70,11 @@ class AspectTests extends CatsTaglessTestSuite {
       import weave.codomain.instance
       val hasArgs = weave.domain.nonEmpty
       val method = if (hasArgs) "POST" else "GET"
-      val url = s"https://foo.bar/${weave.codomain.name}"
+      val url = s"https://foo.bar/${weave.codomain.methodName}"
       val body = hasArgs.guard[Option].map { _ =>
         weave.domain.foldLeft(JsonObject.empty) { (body, args) =>
           args.foldLeft(body) { (body, advice) =>
-            body.add(advice.name, advice.instance(advice.target.value))
+            body.add(advice.methodName, advice.instance(advice.target.value))
           }
         }
       }

--- a/tests/src/test/scala/cats/tagless/tests/AspectTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/AspectTests.scala
@@ -41,9 +41,9 @@ class AspectTests extends CatsTaglessTestSuite {
       codomainName: String,
       codomainTarget: List[String]
     ): Assertion = {
-      weave.domain.map(_.map(a => a.methodName -> a.instance.show(a.target.value)).toMap) shouldBe domain
-      weave.codomain.algebraName shouldBe algebraName
-      weave.codomain.methodName shouldBe codomainName
+      weave.domain.map(_.map(a => a.name -> a.instance.show(a.target.value)).toMap) shouldBe domain
+      weave.algebraName shouldBe algebraName
+      weave.codomain.name shouldBe codomainName
       weave.codomain.target.map(weave.codomain.instance.show) shouldBe codomainTarget
     }
 
@@ -70,11 +70,11 @@ class AspectTests extends CatsTaglessTestSuite {
       import weave.codomain.instance
       val hasArgs = weave.domain.nonEmpty
       val method = if (hasArgs) "POST" else "GET"
-      val url = s"https://foo.bar/${weave.codomain.methodName}"
+      val url = s"https://foo.bar/${weave.codomain.name}"
       val body = hasArgs.guard[Option].map { _ =>
         weave.domain.foldLeft(JsonObject.empty) { (body, args) =>
           args.foldLeft(body) { (body, advice) =>
-            body.add(advice.methodName, advice.instance(advice.target.value))
+            body.add(advice.name, advice.instance(advice.target.value))
           }
         }
       }

--- a/tests/src/test/scala/cats/tagless/tests/InstrumentTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/InstrumentTests.scala
@@ -32,7 +32,7 @@ class InstrumentTests extends CatsTaglessTestSuite {
     val instrumented = instrument.instrument(store)
     val result = instrumented.get("key1")
 
-    instrument.algebraName shouldBe "KVStore"
+    result.algebraName shouldBe "KVStore"
     result.methodName shouldBe "get"
     result.value shouldBe Some("Test key1")
   }
@@ -45,7 +45,7 @@ class InstrumentTests extends CatsTaglessTestSuite {
     val instrumented = lookup.instrument
     val result = instrumented -> "key1"
 
-    Lookup.instrumentForLookup.algebraName shouldBe "Lookup"
+    result.algebraName shouldBe "Lookup"
     result.methodName shouldBe "->"
     result.value shouldBe Some(1)
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12-SNAPSHOT"
+version in ThisBuild := "0.12-SNAPSHOT-local"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12-SNAPSHOT-local"
+version in ThisBuild := "0.12-SNAPSHOT"


### PR DESCRIPTION
It's quite convenient to have the `algebraName` at the site when transforming the algebra:

```scala
val woven = new PostgresRepos[Aspect.Weave.Codomain[RIO[OpenTracing, *], TraceData, *]] {
   // when call `Derive.aspect.algebraName` you can access it's name, but it doesn't make sense here yet
   def depots = Derive.aspect.weave(repos.depots)
  // more repos here
}

val traceTransformation = new ((Aspect.Weave.Codomain[RIO[OpenTracing, *], TraceData, *]) ~> RIO[OpenTracing, *]) {
  def apply[A](fa: Codomain[RIO[OpenTracing, *], TraceData, A]): RIO[OpenTracing, A] = {
    fa.codomain.target.flatMap { res =>
      fa.codomain.instance.extract(res) match {
        case Some(value) =>
          // here I also would like to access algebra name, to add it to the tag
          OpenTracing.tag("result", value) *> ZIO.succeed(res)
        case None => ZIO.succeed(res)
      }
    }.span(fa.codomain.name)
  }
}

woven.mapK(traceTransformation)
```