### PR TITLE
Add Two New Error Related Methods To FunctorK.

### DIFF
--- a/core/src/main/scala/cats/tagless/FunctorK.scala
+++ b/core/src/main/scala/cats/tagless/FunctorK.scala
@@ -16,18 +16,39 @@
 
 package cats.tagless
 
+import cats._
+import cats.arrow._
+import cats.implicits._
 import simulacrum.typeclass
-import cats.~>
 
 /**
- * Sort of a higher kinded Functor, but, well, it's complcated. 
+ * Sort of a higher kinded Functor, but, well, it's complcated.
  * See Daniel Spiewak's comment here
  * https://github.com/typelevel/cats/issues/2697#issuecomment-453883055
- * Also explains why this isn't in `cats-core`. 
-**/ 
+ * Also explains why this isn't in `cats-core`.
+**/
 @typeclass
 trait FunctorK[A[_[_]]] extends InvariantK[A] {
   def mapK[F[_], G[_]](af: A[F])(fk: F ~> G): A[G]
 
   override def imapK[F[_], G[_]](af: A[F])(fk: F ~> G)(gK: G ~> F): A[G] = mapK(af)(fk)
+
+  /** Perform a transformation on all errors. */
+  final def transformError[F[_], E](af: A[F])(f: E => F[E])(implicit F: MonadError[F, E]): A[F] =
+    mapK(af)(
+      new FunctionK[F, F]{
+        override def apply[B](fa: F[B]): F[B] =
+          fa.handleErrorWith(e =>
+            f(e).flatMap(e => F.raiseError[B](e))
+          )
+      }
+    )
+
+  /** Perform a action on error. For example, one can use this to add logging to
+    * all errors for a given instance of [[FunctorK]].
+    */
+  final def flatTapOnError[F[_], E](af: A[F])(f: E => F[Unit])(implicit F: MonadError[F, E]): A[F] =
+    transformError[F, E](af)(
+      e => f(e) *> F.pure(e)
+    )
 }

--- a/tests/src/test/scala/cats/tagless/tests/TestAlgebras.scala
+++ b/tests/src/test/scala/cats/tagless/tests/TestAlgebras.scala
@@ -17,8 +17,9 @@
 package cats.tagless
 package tests
 
-import cats.{Eq, Eval, Monoid, ~>}
+import cats.{ApplicativeError, Eq, Eval, Monoid, ~>}
 import cats.data.{EitherT, Kleisli, State, Tuple2K}
+import cats.effect._
 import cats.implicits._
 import cats.laws.discipline.ExhaustiveCheck
 import cats.laws.discipline.arbitrary._
@@ -133,6 +134,11 @@ object Interpreters {
   implicit object lazyInterpreter extends SafeAlg[Eval] {
     def parseInt(str: String): Eval[Int] = Eval.later(str.toInt)
     def divide(dividend: Float, divisor: Float): Eval[Float] = Eval.later(dividend / divisor)
+  }
+
+  implicit object syncIOInterpreter extends SafeAlg[SyncIO] {
+    override def parseInt(str: String): SyncIO[Int] = ApplicativeError[SyncIO, Throwable].catchNonFatal(str.toInt)
+    override def divide(dividend: Float, divisor: Float): SyncIO[Float] = ApplicativeError[SyncIO, Throwable].catchNonFatal(dividend / divisor)
   }
 
   object KVStoreInterpreter extends KVStore[State[StateInfo, *]] {


### PR DESCRIPTION
This commit adds two new methods on the `FunctorK` typeclass, `transformError` and `flatTapOnError`.

For any `FunctorK[A]` for which the current `F` on `A[F]` is an instance of `MonadError[F, E]` (for some `E`) we can provide a method which allows for transformation on all `E` values for all methods in the given `A[F]`. This uses the identity `FunctionK` for invocations which do not yield an error and the `handleErrorWith` methods from `MonadError` for the error paths.

The primary motivating use case for these methods is creating a succinct way to define logging in the case of an error for all methods of an F-Algebra. For example with these changes it becomes possible to write something like this,

```scala
trait Logger[F[_]] {
    def error(message: String): F[Unit]
    def warn(message: String): F[Unit]
    def info(message: String): F[Unit]
}

@autoFunctorK
trait FAlgebra[F[_]] {
    def lookupUser(id: Id): F[User]
    def lookupOrder(orderId: OrderId): F[Order]
    def createOrder(order: Order): F[OrderId]
}

object FAlgebra {
    def simpleInstance[F[_]]: FAlgebra[F] = new FAlgebra[F]{
        override def lookupUser(id: Id): F[User] = ???
        override def lookupOrder(orderId: OrderId): F[Order] = ???
        override def createOrder(order: Order): F[OrderId] = ???
    }

    def withErrorLogging[F[_]: Sync](baseInstance: FAlgebra[F], logger: Logger[F]): FAlgebra[F] =
        baseInstance.flatTapOnError{
            case t: Throwable =>
                logger.error(t.getMessage)
        }
}

```