### PR TITLE
remove explicit scalatestplus-scalacheck dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
 addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\"")
 
 lazy val libs = org.typelevel.libraries
-  .add("scalatestplus", version = "3.2.2.0", org = "org.scalatestplus", "scalacheck-1-14")
   .add("discipline-scalatest", version = "2.1.0", org = org.typelevel.typeLevelOrg)
   .add("cats", version = "2.3.0")
   .add("paradise", version = "2.1.1")
@@ -83,7 +82,6 @@ lazy val testsM = module("tests", CrossType.Pure)
       "cats-free",
       "cats-effect",
       "cats-testkit",
-      "scalacheck-1-14",
       "discipline-scalatest",
       "circe-core"
     ),


### PR DESCRIPTION
The artifact name changed, which means that it is on the classpath twice now. Instead, drop the direct dependency and let discipline-scalatest pull it in.