### PR TITLE
Add license to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,7 @@ lazy val commonNativeSettings = List(
 )
 
 ThisBuild / homepage := Some(url(homePage))
+ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
   Developer(
     "Georgi Krastev",


### PR DESCRIPTION
See https://github.com/sbt/sbt/releases/tag/v1.6.2
This is just adding the existing license to the build.

@armanbilge hmm any idea why it's complaining?
I noticed that it worked fine for you in typelevel/kittens#429