### PR TITLE
check binary compatibility with v0.14.0 wherever possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,7 @@ lazy val commonSettings = List(
   apiURL := Some(url("https://typelevel.org/cats-tagless/api/")),
   autoAPIMappings := true,
   tlVersionIntroduced := Map("3" -> "0.15.0"),
+  tlMimaPreviousVersions ++= when(scalaBinaryVersion.value.startsWith("2"))("0.14.0").toSet,
   // sbt-typelevel sets -source:3.0-migration, we'd like to replace it with -source:future
   scalacOptions ~= (_.filterNot(_ == "-source:3.0-migration")),
   scalacOptions ++= (scalaBinaryVersion.value match {


### PR DESCRIPTION
I was hopeful that v0.15.0 is binary-compatible with v0.14.0, but I wanted to check it before relying on that. MiMa reports they are compatible, so we can enforce that going forward with this change.