### PR TITLE
Scala3 SemigroupalK and InvariantK macros

### DIFF
--- a/core/src/main/scala-3/cats/tagless/derived/DerivedInvariantK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedInvariantK.scala
@@ -16,4 +16,8 @@
 
 package cats.tagless.derived
 
-trait DerivedInvariantK
+import cats.tagless.macros.Derive
+import scala.annotation.experimental
+
+trait DerivedInvariantK:
+  @experimental inline def derived[Alg[_[_]]] = Derive.invariantK[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/DerivedSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedSemigroupalK.scala
@@ -16,4 +16,8 @@
 
 package cats.tagless.derived
 
-trait DerivedSemigroupalK
+import cats.tagless.macros.Derive
+import scala.annotation.experimental
+
+trait DerivedSemigroupalK:
+  @experimental inline def derived[Alg[_[_]]] = Derive.semigroupalK[Alg]

--- a/core/src/main/scala-3/cats/tagless/macros/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/Derive.scala
@@ -21,3 +21,5 @@ import scala.annotation.experimental
 
 object Derive:
   @experimental inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
+  @experimental inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
+  @experimental inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/macros/macroInvariantK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroInvariantK.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.tagless.*
+import cats.~>
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroInvariantK:
+  inline def derive[Alg[_[_]]] = ${ invariantK[Alg] }
+
+  def invariantK[Alg[_[_]]: Type](using Quotes): Expr[InvariantK[Alg]] = '{
+      new InvariantK[Alg]:
+        def imapK[F[_], G[_]](alg: Alg[F])(fk: F ~> G)(gk: G ~> F): Alg[G] =
+          ${ deriveIMapK('alg, 'fk, 'gk) }
+    }
+
+  def deriveIMapK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
+      alg: Expr[Alg[F]],
+      fk: Expr[F ~> G],
+      gk: Expr[G ~> F]
+  )(using q: Quotes): Expr[Alg[G]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val F = TypeRepr.of[F]
+    val G = TypeRepr.of[G]
+    val g = G.typeSymbol
+
+    alg.asTerm.transformTo[Alg[G]](
+      args = {
+        case (tpe, arg) if tpe.contains(g) =>
+          Select
+            .unique(tpe.summonLambda[InvariantK](g), "imapK")
+            .appliedToTypes(List(G, F))
+            .appliedTo(arg)
+            .appliedTo(gk.asTerm)
+            .appliedTo(fk.asTerm)
+      },
+
+      body = {
+        case (tpe, body) if tpe.contains(g) =>
+          Select
+            .unique(tpe.summonLambda[InvariantK](g), "imapK")
+            .appliedToTypes(List(F, G))
+            .appliedTo(body)
+            .appliedTo(fk.asTerm)
+            .appliedTo(gk.asTerm)
+      }
+    )

--- a/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.tagless.*
+import cats.data.Tuple2K
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroSemigroupalK:
+  inline def derive[Alg[_[_]]] = ${ semigroupalK[Alg] }
+
+  def semigroupalK[Alg[_[_]]: Type](using Quotes): Expr[SemigroupalK[Alg]] = '{
+    new SemigroupalK[Alg]:
+      def productK[F[_], G[_]](af: Alg[F], ag: Alg[G]): Alg[Tuple2K[F, G, *]] =
+        ${ deriveProductK('af, 'ag) }
+  }
+
+  def deriveProductK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
+      eaf: Expr[Alg[F]],
+      eag: Expr[Alg[G]]
+  )(using q: Quotes): Expr[Alg[Tuple2K[F, G, *]]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val F = TypeRepr.of[F]
+    val G = TypeRepr.of[G]
+    val H = TypeRepr.of[Tuple2K[F, G, *]]
+    val f = F.typeSymbol
+    val h = H.typeSymbol
+
+    List(eaf.asTerm, eag.asTerm).transform[Alg[Tuple2K[F, G, *]]] {
+      case (tpe, argf :: argg :: Nil) if tpe.contains(h) =>
+        Select
+          .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[SemigroupalK](f), "productK")
+          .appliedToTypes(List(F, G))
+          .appliedTo(argf, argg)
+    }

--- a/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
@@ -30,7 +30,7 @@ import scala.annotation.experimental
 
 // TODO: @finalAlg @autoProductNK @autoInstrument
 @experimental
-trait SafeAlg[F[_]] derives FunctorK: // , SemigroupalK:
+trait SafeAlg[F[_]] derives FunctorK, SemigroupalK:
   def parseInt(str: String): F[Int]
   def divide(dividend: Float, divisor: Float): F[Float]
 
@@ -53,7 +53,8 @@ object SafeAlg:
 
 // TODO: Macro should support it
 // TODO: @finalAlg
-trait SafeInvAlg[F[_]]: // derives InvariantK, SemigroupalK:
+@experimental
+trait SafeInvAlg[F[_]] derives InvariantK, SemigroupalK:
   def parseInt(fs: String): F[Int]
   // def parseInt(fs: F[String]): F[Int]
   // def doubleParser(precision: Int): Kleisli[F, String, Double]
@@ -88,7 +89,8 @@ object SafeInvAlg:
       // def doubleParser(precision: Int) = doubleParserF(precision)
       // def parseIntOrError(fs: EitherT[F, String, String]) = parseIntOrErrorF(fs)
   )
-trait CalculatorAlg[F[_]]: // derives SemigroupalK, InvariantK:
+@experimental
+trait CalculatorAlg[F[_]] derives InvariantK, SemigroupalK:
   def lit(i: Int): F[Int]
   // def add(x: F[Int], y: F[Int]): F[Int]
   // def show[A](expr: F[A]): String

--- a/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.tagless.syntax.all.*
+import cats.~>
+import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary.*
+import cats.tagless.laws.discipline.InvariantKTests
+
+import scala.annotation.nowarn
+import scala.util.Try
+import scala.annotation.experimental
+
+@experimental
+class autoInvariantKTests extends CatsTaglessTestSuite:
+  import autoInvariantKTests.*
+
+  checkAll("InvariantK[SafeInvAlg]", InvariantKTests[SafeInvAlg].invariantK[Try, Option, List])
+  checkAll("InvariantK[CalculatorAlg]", InvariantKTests[CalculatorAlg].invariantK[Try, Option, List])
+  checkAll("InvariantK is Serializable", SerializableTests.serializable(InvariantK[SafeInvAlg]))
+
+  test("Alg with non effect method") {
+    val tryInt = new NoEffectMethod[Try]:
+      def a(i: Int): Int = i
+
+    assertEquals(tryInt.imapK(toFk)(otFk).a(2), 2)
+  }
+
+  // test("Alg with contravariant Eff method") {
+  //   val tryInt = new ContravariantEff[Try] {
+  //     def a(i: Try[Int], j: String): Int = i.get
+  //     def b(i: Try[Int]): Int = i.get
+  //   }
+
+  //   val oInt = tryInt.imapK(toFk)(otFk)
+  //   assertEquals(oInt.a(Option(2), "ignored"), 2)
+  //   assertEquals(oInt.b(Option(3)), 3)
+  // }
+
+  // test("Alg with Invariant effect method") {
+  //   val tryInt = new InvariantEff[Try] {
+  //     def a(i: Try[Int], j: String): Try[Int] = i
+  //   }
+
+  //   val oInt = tryInt.imapK(toFk)(otFk)
+  //   assertEquals(oInt.a(Option(2), "ignored"), Some(2))
+  // }
+
+  // test("Alg with extra type parameters auto derivation") {
+  //   implicit object algWithExtraTP extends WithExtraTpeParam[Try, String] {
+  //     def a(i: Try[String]) = i
+  //     def b(i: Try[Int]) = i.map(_.toString)
+  //   }
+  //   import WithExtraTpeParam.autoDerive.*
+  //   assertEquals(WithExtraTpeParam[Option, String].a(Some("5")), Some("5"))
+  //   assertEquals(WithExtraTpeParam[Option, String].b(Some(5)), Some("5"))
+  // }
+
+  // test("Alg with extra type parameters before effect type") {
+  //   implicit val algWithExtraTP: AlgWithExtraTP2[String, Try] = new AlgWithExtraTP2[String, Try] {
+  //     def a(i: Try[Int]) = i.map(_.toString)
+  //   }
+  //   import AlgWithExtraTP2.autoDerive.*
+  //   assertEquals(AlgWithExtraTP2[String, Option].a(Some(5)), Some("5"))
+  // }
+
+  // test("Alg with type member") {
+  //   implicit val tryInt = new AlgWithTypeMember[Try] {
+  //     type T = String
+  //     def a(i: Try[String]): Try[String] = i.map(_ + "a")
+  //   }
+
+  //   assertEquals(AlgWithTypeMember.imapK(tryInt)(toFk)(otFk).a(Some("4")), Some("4a"))
+  // }
+
+  // test("Alg with type member fully refined") {
+  //   implicit val tryInt = new AlgWithTypeMember[Try] {
+  //     type T = String
+  //     def a(i: Try[String]): Try[String] = i.map(_ + "a")
+  //   }
+
+  //   import AlgWithTypeMember.fullyRefined.*
+  //   import AlgWithTypeMember.fullyRefined.autoDerive.*
+
+  //   val algAux: AlgWithTypeMember.Aux[Option, String] = implicitly
+  //   assertEquals(algAux.a(Some("4")), Some("4a"))
+  // }
+
+  // test("turn off auto derivation") {
+  //   @nowarn("cat=unused")
+  //   implicit object foo extends AlgWithoutAutoDerivation[Try] {
+  //     def a(i: Try[Int]): Try[Int] = i
+  //   }
+
+  //   assertNoDiff(
+  //     compileErrors("AlgWithoutAutoDerivation.autoDerive"),
+  //     """|error: value autoDerive is not a member of object cats.tagless.tests.autoInvariantKTests.AlgWithoutAutoDerivation
+  //        |AlgWithoutAutoDerivation.autoDerive
+  //        |                         ^
+  //        |""".stripMargin
+  //   )
+  // }
+
+  // test("with default impl") {
+  //   implicit object foo extends AlgWithDefaultImpl[Try]
+  //   assertEquals(foo.imapK(toFk)(otFk).const(Option(1)), Some(1))
+  // }
+
+  // test("with methods with type param") {
+  //   implicit object foo extends AlgWithTypeParam[Try] {
+  //     def a[T](i: Try[T]): Try[String] = i.map(_.toString)
+  //   }
+  //   assertEquals(foo.imapK(toFk)(otFk).a(Option(1)), Some("1"))
+  // }
+
+@experimental
+object autoInvariantKTests:
+  implicit val toFk: Try ~> Option = FunctionKLift[Try, Option](_.toOption)
+  implicit val otFk: Option ~> Try = FunctionKLift[Option, Try](o => Try(o.get))
+
+  trait NoEffectMethod[F[_]] derives InvariantK:
+    def a(i: Int): Int
+
+  // trait ContravariantEff[F[_]] derives InvariantK {
+  //   def a(i: F[Int], j: String): Int
+  //   def b(i: F[Int]): Int
+  // }
+
+  // trait InvariantEff[F[_]] derives InvariantK {
+  //   def a(i: F[Int], j: String): F[Int]
+  // }
+
+  // TODO: @finalAlg
+  // trait AlgWithTypeMember[F[_]] derives InvariantK {
+  //   type T
+  //   def a(i: F[T]): F[T]
+  // }
+
+  // object AlgWithTypeMember {
+  //   type Aux[F[_], T0] = AlgWithTypeMember[F] { type T = T0 }
+  // }
+
+  // TODO: @finalAlg
+  // trait WithExtraTpeParam[F[_], T] derives InvariantK {
+  //   def a(i: F[T]): F[T]
+  //   def b(i: F[Int]): F[T]
+  // }
+
+  // TODO: @finalAlg
+  // trait AlgWithExtraTP2[T, F[_]] derives InvariantK {
+  //   def a(i: F[Int]): F[T]
+  // }
+
+  // trait AlgWithoutAutoDerivation[F[_]] derives InvariantK {
+  //   def a(i: F[Int]): F[Int]
+  // }
+
+  // // @finalAlg
+  // trait AlgWithDef[F[_]] derives InvariantK {
+  //   def a: F[Int]
+  //   def b(c: F[Int]): F[String]
+  // }
+
+  // @finalAlg
+  trait AlgWithDefaultImpl[F[_]] derives InvariantK:
+    def const(i: F[Int]): F[Int] = i
+
+  // @finalAlg
+  // trait AlgWithTypeParam[F[_]] derives InvariantK {
+  //   def a[T](i: F[T]): F[String]
+  // }
+
+  // @finalAlg
+  // trait AlgWithCurryMethod[F[_]] derives InvariantK {
+  //   def a(t: F[Int])(b: String): F[String]
+  // }
+
+  trait AlgWithVarArgsParameter[F[_]] derives InvariantK:
+    def sum(xs: Int*): Int
+    def covariantSum(xs: Int*): F[Int]
+    // def contravariantSum(xs: F[Int]*): Int
+    // def invariantSum(xs: F[Int]*): F[Int]
+
+  // trait AlgWithByNameParameter[F[_]] derives InvariantK {
+  //   def whenM(cond: F[Boolean])(action: => F[Unit]): F[Unit]
+  // }

--- a/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.Eq
+import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary.*
+import cats.tagless.laws.discipline.SemigroupalKTests
+
+import scala.util.Try
+import scala.annotation.experimental
+
+@experimental
+class autoSemigroupalKTests extends CatsTaglessTestSuite:
+  type T3K[A] = Tuple3K[Try, Option, List]#λ[A]
+  // Type inference issues on Scala 2.12
+  implicit val eqForSafeAlg: Eq[SafeAlg[T3K]] = SafeAlg.eqForSafeAlg[T3K]
+  implicit val eqForSafeInvAlg: Eq[SafeInvAlg[T3K]] = SafeInvAlg.eqForSafeInvAlg[T3K]
+  implicit val eqForCalculatorAlg: Eq[CalculatorAlg[T3K]] = CalculatorAlg.eqForCalculatorAlg[T3K]
+
+  checkAll("SemigroupalK[SafeAlg]", SemigroupalKTests[SafeAlg].semigroupalK[Try, Option, List])
+  checkAll("SemigroupalK[SafeInvAlg]", SemigroupalKTests[SafeInvAlg].semigroupalK[Try, Option, List])
+  checkAll("SemigroupalK[CalculatorAlg]", SemigroupalKTests[CalculatorAlg].semigroupalK[Try, Option, List])
+  checkAll("SemigroupalK is Serializable", SerializableTests.serializable(SemigroupalK[SafeAlg]))
+
+  test("simple product") {
+    val prodInterpreter = Interpreters.tryInterpreter.productK(Interpreters.lazyInterpreter)
+    assertEquals(prodInterpreter.parseInt("3").first, Try(3))
+    assertEquals(prodInterpreter.parseInt("3").second.value, 3)
+    assertEquals(prodInterpreter.parseInt("sd").first.isSuccess, false)
+    assertEquals(prodInterpreter.divide(3f, 3f).second.value, 1f)
+  }
+
+object autoSemigroupalKTests:
+
+  trait algWithGenericType[F[_]] derives SemigroupalK:
+    def a[T](a: T): F[Unit]
+
+  trait algWithCurryMethod[F[_]] derives SemigroupalK:
+    def a(b: String)(d: Int): F[Unit]
+
+  trait AlgWithVarArgsParameter[F[_]] derives SemigroupalK:
+    def sum(xs: Int*): Int
+    def effectfulSum(xs: Int*): F[Int]

--- a/tests/src/test/scala-3/cats/tagless/tests/simple/Fixtures.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/simple/Fixtures.scala
@@ -23,7 +23,7 @@ import scala.annotation.experimental
 @experimental
 trait Fixtures:
   /** Simple algebra definition */
-  trait SimpleService[F[_]] derives FunctorK:
+  trait SimpleService[F[_]] derives FunctorK, SemigroupalK:
     def id(): F[Int]
     def list(id: Int): F[List[Int]]
     def lists(id1: Int, id2: Int): F[List[Int]]

--- a/tests/src/test/scala-3/cats/tagless/tests/simple/InvariantKSpec.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/simple/InvariantKSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.simple
+
+import cats.tagless.*
+import cats.tagless.syntax.all.*
+import cats.tagless.macros.*
+
+import cats.Id
+import cats.arrow.FunctionK
+import cats.~>
+
+import scala.compiletime.testing.*
+import scala.annotation.experimental
+
+@experimental
+class InvariantKSpec extends munit.FunSuite with Fixtures:
+  test("DeriveMacro should derive instance for a simple algebra") {
+    val invariantK = Derive.invariantK[SimpleService]
+    assert(invariantK.isInstanceOf[InvariantK[SimpleService]])
+  }
+
+  test("InvariantK should be a valid instance for a simple algebra") {
+    val invariantK = Derive.invariantK[SimpleService]
+    val functorK = Derive.functorK[SimpleService]
+
+    val fk: Id ~> Option = FunctionK.lift([X] => (id: Id[X]) => Option(id))
+    val gk: Option ~> Id = FunctionK.lift([X] => (id: Option[X]) => id.get)
+    val invariantInstance = invariantK.imapK(instance)(fk)(gk)
+    val optionalInstance = functorK.mapK(instance)(fk)
+
+    assertEquals(invariantInstance.id(), optionalInstance.id())
+    assertEquals(invariantInstance.list(0), optionalInstance.list(0))
+    assertEquals(invariantInstance.lists(0, 1), optionalInstance.lists(0, 1))
+    assertEquals(invariantInstance.paranthesless, optionalInstance.paranthesless)
+    assertEquals(invariantInstance.tuple, optionalInstance.tuple)
+  }
+
+  test("DeriveMacro should not derive instance for a not simple algebra") {
+    assert(typeCheckErrors("Derive.invariantK[NotSimpleService]").isEmpty)
+  }
+
+  test("InvariantK derives syntax") {
+    val fk: Id ~> Option = FunctionK.lift([X] => (id: Id[X]) => Option(id))
+    val gk: Option ~> Id = FunctionK.lift([X] => (id: Option[X]) => id.get)
+    val invariantInstance = instance.imapK(fk)(gk)
+    val optionalInstance = instance.mapK(fk)
+
+    assertEquals(invariantInstance.id(), optionalInstance.id())
+    assertEquals(invariantInstance.list(0), optionalInstance.list(0))
+    assertEquals(invariantInstance.lists(0, 1), optionalInstance.lists(0, 1))
+    assertEquals(invariantInstance.paranthesless, optionalInstance.paranthesless)
+    assertEquals(invariantInstance.tuple, optionalInstance.tuple)
+  }

--- a/tests/src/test/scala-3/cats/tagless/tests/simple/SemigroupalKSpec.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/simple/SemigroupalKSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.simple
+
+import cats.tagless.*
+import cats.tagless.syntax.all.*
+import cats.tagless.macros.*
+
+import cats.Id
+import cats.arrow.FunctionK
+import cats.data.Tuple2K
+
+import scala.compiletime.testing.*
+import scala.annotation.experimental
+
+@experimental
+class SemigroupalKSpec extends munit.FunSuite with Fixtures:
+  test("DeriveMacro should derive instance for a simple algebra") {
+    val semigroupalK = Derive.semigroupalK[SimpleService]
+    assert(semigroupalK.isInstanceOf[SemigroupalK[SimpleService]])
+  }
+
+  test("SemigorupalK should be a valid instance for a simple algebra") {
+    val functorK = Derive.functorK[SimpleService]
+    val semigroupalK = Derive.semigroupalK[SimpleService]
+    val optionalInstance = functorK.mapK(instance)(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val combinedInstance = semigroupalK.productK(instance, optionalInstance)
+
+    assertEquals(combinedInstance.id(), Tuple2K(instance.id(), optionalInstance.id()))
+    assertEquals(combinedInstance.list(0), Tuple2K(instance.list(0), optionalInstance.list(0)))
+    assertEquals(combinedInstance.lists(0, 1), Tuple2K(instance.lists(0, 1), optionalInstance.lists(0, 1)))
+    assertEquals(combinedInstance.paranthesless, Tuple2K(instance.paranthesless, optionalInstance.paranthesless))
+    assertEquals(combinedInstance.tuple, Tuple2K(instance.tuple, optionalInstance.tuple))
+  }
+
+  test("DeriveMacro should not derive instance for a not simple algebra") {
+    assert(typeCheckErrors("Derive.semigroupalK[NotSimpleService]").isEmpty)
+  }
+
+  test("SemigroupalK derives syntax") {
+    val optionalInstance = instance.mapK(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val combinedInstance = instance.productK(optionalInstance)
+
+    assertEquals(combinedInstance.id(), Tuple2K(instance.id(), optionalInstance.id()))
+    assertEquals(combinedInstance.list(0), Tuple2K(instance.list(0), optionalInstance.list(0)))
+    assertEquals(combinedInstance.lists(0, 1), Tuple2K(instance.lists(0, 1), optionalInstance.lists(0, 1)))
+    assertEquals(combinedInstance.paranthesless, Tuple2K(instance.paranthesless, optionalInstance.paranthesless))
+    assertEquals(combinedInstance.tuple, Tuple2K(instance.tuple, optionalInstance.tuple))
+  }


### PR DESCRIPTION
- **SemigroupalK**
  - [x] `A => F[_]`
  - [ ] `A => Kleisli / WriterT / WriterT / etc`
    - is there a generic solution?
  - [ ] `Kleisli / WriterT / WriterT / etc` => `A`
  - [x] `algWithGenericType`
  - [x] `algWithCurryMethod`
  - [x] Varargs
    - [x]  `AlgWithVarArgsParameter`
- **InvariantK**
  - [x] `A => F[_]`
  - [ ] `A => U[F]`
  - [ ] `F[_] => F[_]`
  - [ ] `A => Kleisli / WriterT / WriterT / etc`
    - is there a generic solution?
  - [ ] `Kleisli / WriterT / WriterT / etc` => `A`
  - [ ] `NoEffectMethod`
  - [ ] `ContravariantEff`
  - [ ] `InvariantEff`
  - [ ] `AlgWithTypeMember`
  - [ ] Algebras with extra Type Parameters 
    - [ ] `WithExtraTpeParam`
    - [ ] `AlgWithExtraTP2` 
  - [ ] `AlgWithDef`
  - [ ] `AlgWithTypeParam`
  - [ ] `AlgWithCurryMethod`
  - [ ] Varargs
    - [ ]  `AlgWithVarArgsParameter`
  - [ ] `AlgWithByNameParameter`

Mb I was too hasty and it makes sense to deal with invariant in a separate PR.