### PR TITLE
Scala3 ApplyK macros and SemigroupalK derivation improvement

### DIFF
--- a/core/src/main/scala-3/cats/tagless/macros/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/Derive.scala
@@ -23,4 +23,5 @@ object Derive:
   @experimental inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
   @experimental inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
   @experimental inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]
+  @experimental inline def applyK[Alg[_[_]]]: ApplyK[Alg] = MacroApplyK.derive[Alg]
   @experimental inline def contravariantK[Alg[_[_]]]: ContravariantK[Alg] = MacroContravariantK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/macros/macroApplyK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroApplyK.scala
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 
-package cats.tagless.derived
+package cats.tagless.macros
 
-import cats.tagless.macros.Derive
+import cats.tagless.*
+import cats.~>
+import cats.data.Tuple2K
+
 import scala.annotation.experimental
+import scala.quoted.*
 
-trait DerivedApplyK:
-  @experimental inline def derived[Alg[_[_]]] = Derive.applyK[Alg]
+@experimental
+object MacroApplyK:
+  inline def derive[Alg[_[_]]] = ${ applyK[Alg] }
+
+  def applyK[Alg[_[_]]: Type](using Quotes): Expr[ApplyK[Alg]] = '{
+    new ApplyK[Alg]:
+      def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] =
+        ${ MacroFunctorK.deriveMapK('af, 'fk) }
+      def productK[F[_], G[_]](af: Alg[F], ag: Alg[G]): Alg[Tuple2K[F, G, *]] =
+        ${ MacroSemigroupalK.deriveProductK('af, 'ag) }
+  }

--- a/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
@@ -39,6 +39,8 @@ object MacroSemigroupalK:
     import quotes.reflect.*
     given DeriveMacros[q.type] = new DeriveMacros
 
+    extension (tpe: TypeRepr) def fromTuple2K: TypeRepr = tpe.typeArgs.head.appliedTo(tpe.typeArgs.last)
+
     val F = TypeRepr.of[F]
     val G = TypeRepr.of[G]
     val H = TypeRepr.of[Tuple2K[F, G, *]]
@@ -50,7 +52,7 @@ object MacroSemigroupalK:
         {
           case (tpe, arg) if tpe.contains(h) =>
             Select
-              .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[FunctorK](f), "mapK")
+              .unique(tpe.fromTuple2K.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(H, F))
               .appliedTo(arg)
               .appliedTo(
@@ -62,7 +64,7 @@ object MacroSemigroupalK:
         {
           case (tpe, arg) if tpe.contains(h) =>
             Select
-              .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[FunctorK](f), "mapK")
+              .unique(tpe.fromTuple2K.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(H, G))
               .appliedTo(arg)
               .appliedTo(
@@ -75,7 +77,7 @@ object MacroSemigroupalK:
       body = {
         case (tpe, argf :: argg :: Nil) if tpe.contains(h) =>
           Select
-            .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[SemigroupalK](f), "productK")
+            .unique(tpe.fromTuple2K.summonLambda[SemigroupalK](f), "productK")
             .appliedToTypes(List(F, G))
             .appliedTo(argf, argg)
       }

--- a/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
@@ -38,7 +38,6 @@ object MacroSemigroupalK:
   )(using q: Quotes): Expr[Alg[Tuple2K[F, G, *]]] =
     import quotes.reflect.*
     given DeriveMacros[q.type] = new DeriveMacros
-
     extension (tpe: TypeRepr) def fromTuple2K: TypeRepr = tpe.typeArgs.head.appliedTo(tpe.typeArgs.last)
 
     val F = TypeRepr.of[F]
@@ -46,6 +45,8 @@ object MacroSemigroupalK:
     val H = TypeRepr.of[Tuple2K[F, G, *]]
     val f = F.typeSymbol
     val h = H.typeSymbol
+
+    def tuple2K(name: String): Term = Select.unique('{ SemigroupalK }.asTerm, name).appliedToTypes(List(F, G))
 
     List(eaf.asTerm, eag.asTerm).transform[Alg[Tuple2K[F, G, *]]](
       args = List(
@@ -55,11 +56,7 @@ object MacroSemigroupalK:
               .unique(tpe.fromTuple2K.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(H, F))
               .appliedTo(arg)
-              .appliedTo(
-                Select
-                  .unique('{ SemigroupalK }.asTerm, "firstK")
-                  .appliedToTypes(List(F, G))
-              )
+              .appliedTo(tuple2K("firstK"))
         },
         {
           case (tpe, arg) if tpe.contains(h) =>
@@ -67,11 +64,7 @@ object MacroSemigroupalK:
               .unique(tpe.fromTuple2K.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(H, G))
               .appliedTo(arg)
-              .appliedTo(
-                Select
-                  .unique('{ SemigroupalK }.asTerm, "secondK")
-                  .appliedToTypes(List(F, G))
-              )
+              .appliedTo(tuple2K("secondK"))
         }
       ),
       body = {

--- a/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/macroSemigroupalK.scala
@@ -45,10 +45,38 @@ object MacroSemigroupalK:
     val f = F.typeSymbol
     val h = H.typeSymbol
 
-    List(eaf.asTerm, eag.asTerm).transform[Alg[Tuple2K[F, G, *]]] {
-      case (tpe, argf :: argg :: Nil) if tpe.contains(h) =>
-        Select
-          .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[SemigroupalK](f), "productK")
-          .appliedToTypes(List(F, G))
-          .appliedTo(argf, argg)
-    }
+    List(eaf.asTerm, eag.asTerm).transform[Alg[Tuple2K[F, G, *]]](
+      args = List(
+        {
+          case (tpe, arg) if tpe.contains(h) =>
+            Select
+              .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[FunctorK](f), "mapK")
+              .appliedToTypes(List(H, F))
+              .appliedTo(arg)
+              .appliedTo(
+                Select
+                  .unique('{ SemigroupalK }.asTerm, "firstK")
+                  .appliedToTypes(List(F, G))
+              )
+        },
+        {
+          case (tpe, arg) if tpe.contains(h) =>
+            Select
+              .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[FunctorK](f), "mapK")
+              .appliedToTypes(List(H, G))
+              .appliedTo(arg)
+              .appliedTo(
+                Select
+                  .unique('{ SemigroupalK }.asTerm, "secondK")
+                  .appliedToTypes(List(F, G))
+              )
+        }
+      ),
+      body = {
+        case (tpe, argf :: argg :: Nil) if tpe.contains(h) =>
+          Select
+            .unique(tpe.typeArgs.head.appliedTo(tpe.typeArgs.last).summonLambda[SemigroupalK](f), "productK")
+            .appliedToTypes(List(F, G))
+            .appliedTo(argf, argg)
+      }
+    )

--- a/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
@@ -55,13 +55,12 @@ object SafeAlg:
 // TODO: @finalAlg
 @experimental
 trait SafeInvAlg[F[_]] derives InvariantK, SemigroupalK:
-  def parseInt(fs: String): F[Int]
-  // def parseInt(fs: F[String]): F[Int]
+  def parseInt(fs: F[String]): F[Int]
   // def doubleParser(precision: Int): Kleisli[F, String, Double]
   // def parseIntOrError(fs: EitherT[F, String, String]): F[Int]
 
 object SafeInvAlg:
-  import TestInstances.*
+  // import TestInstances.*
 
   implicit def eqForSafeInvAlg[F[_]](implicit
       eqFi: Eq[F[Int]],
@@ -79,21 +78,19 @@ object SafeInvAlg:
       arbFd: Arbitrary[F[Double]]
   ): Arbitrary[SafeInvAlg[F]] = Arbitrary(
     for
-      parseIntF <- Arbitrary.arbitrary[String => F[Int]]
-      // parseIntF <- Arbitrary.arbitrary[F[String] => F[Int]]
+      parseIntF <- Arbitrary.arbitrary[F[String] => F[Int]]
       doubleParserF <- Arbitrary.arbitrary[Int => Kleisli[F, String, Double]]
       parseIntOrErrorF <- Arbitrary.arbitrary[EitherT[F, String, String] => F[Int]]
     yield new SafeInvAlg[F]:
-      def parseInt(fs: String) = parseIntF(fs)
-      // def parseInt(fs: F[String]) = parseIntF(fs)
-      // def doubleParser(precision: Int) = doubleParserF(precision)
-      // def parseIntOrError(fs: EitherT[F, String, String]) = parseIntOrErrorF(fs)
+      def parseInt(fs: F[String]) = parseIntF(fs)
+      def doubleParser(precision: Int) = doubleParserF(precision)
+      def parseIntOrError(fs: EitherT[F, String, String]) = parseIntOrErrorF(fs)
   )
 @experimental
 trait CalculatorAlg[F[_]] derives InvariantK, SemigroupalK:
   def lit(i: Int): F[Int]
-  // def add(x: F[Int], y: F[Int]): F[Int]
-  // def show[A](expr: F[A]): String
+  def add(x: F[Int], y: F[Int]): F[Int]
+  def show[A](expr: F[A]): String
 
 object CalculatorAlg:
   import TestInstances.*
@@ -102,7 +99,7 @@ object CalculatorAlg:
       eqFi: Eq[F[Int]],
       exFi: ExhaustiveCheck[F[Int]]
   ): Eq[CalculatorAlg[F]] = Eq.by { algebra =>
-    (algebra.lit /*, algebra.add, algebra.show[Int]*/ )
+    (algebra.lit, algebra.add, algebra.show[Int])
   }
 
   implicit def arbitraryCalculatorAlg[F[_]](implicit

--- a/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.Eq
+import cats.data.EitherT
+import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary.*
+import cats.laws.discipline.eq.*
+import cats.tagless.laws.discipline.ApplyKTests
+import org.scalacheck.Arbitrary
+
+import scala.util.Try
+import scala.annotation.experimental
+
+@experimental
+class autoApplyKTests extends CatsTaglessTestSuite:
+  import cats.tagless.tests.autoApplyKTests.AutoApplyKTestAlg
+
+  // Type inference limitation.
+  implicit val eqTuple3K: Eq[AutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ]] =
+    AutoApplyKTestAlg.eqForAutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ]
+  checkAll("ApplyK[AutoApplyKTestAlg]", ApplyKTests[AutoApplyKTestAlg].applyK[Try, Option, List, Int])
+  checkAll("ApplyK is Serializable", SerializableTests.serializable(ApplyK[AutoApplyKTestAlg]))
+
+object autoApplyKTests:
+
+  trait AutoApplyKTestAlg[F[_]] derives ApplyK:
+    def parseInt(str: String): F[Int]
+    // TODO: Macro should handle it
+    // def parseDouble(str: String): EitherT[F, String, Double]
+    def divide(dividend: Float, divisor: Float): F[Float]
+
+  object AutoApplyKTestAlg:
+    import TestInstances.*
+
+    implicit def eqForAutoApplyKTestAlg[F[_]](implicit
+        eqFi: Eq[F[Int]],
+        eqFf: Eq[F[Float]],
+        eqEfd: Eq[EitherT[F, String, Double]]
+    ): Eq[AutoApplyKTestAlg[F]] = Eq.by { algebra =>
+      (algebra.parseInt, /*algebra.parseDouble,*/ algebra.divide)
+    }
+
+    implicit def arbitraryAutoApplyKTestAlg[F[_]](implicit
+        arbFi: Arbitrary[F[Int]],
+        arbFf: Arbitrary[F[Float]],
+        arbEfd: Arbitrary[EitherT[F, String, Double]]
+    ): Arbitrary[AutoApplyKTestAlg[F]] = Arbitrary {
+      for
+        pInt <- Arbitrary.arbitrary[String => F[Int]]
+        pDouble <- Arbitrary.arbitrary[String => EitherT[F, String, Double]]
+        div <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
+      yield new AutoApplyKTestAlg[F]:
+        def parseInt(str: String) = pInt(str)
+        def parseDouble(str: String) = pDouble(str)
+        def divide(dividend: Float, divisor: Float) = div(dividend, divisor)
+    }
+
+  trait AlgWithVarArgsParameter[F[_]] derives ApplyK:
+    def sum(xs: Int*): Int
+    def fSum(xs: Int*): F[Int]

--- a/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
@@ -185,4 +185,3 @@ object autoInvariantKTests:
 
   // trait AlgWithByNameParameter[F[_]] derives InvariantK:
   //   def whenM(cond: F[Boolean])(action: => F[Unit]): F[Unit]
-  //

--- a/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
@@ -58,7 +58,7 @@ object autoSemigroupalKTests:
     def sum(xs: Int*): Int
     def effectfulSum(xs: Int*): F[Int]
 
-  trait AlgWithConstantReturnTypes[F[_]] /*derives SemigroupalK*/:
+  trait AlgWithConstantReturnTypes[F[_]] derives SemigroupalK:
     def pure[A](x: A): F[A]
     def unsafeRun[A](t: F[A]): A
     def toError(t: F[Int]): Exception

--- a/tests/src/test/scala-3/cats/tagless/tests/simple/ApplyKSpec.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/simple/ApplyKSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.simple
+
+import cats.tagless.*
+import cats.tagless.syntax.all.*
+import cats.tagless.macros.*
+
+import cats.Id
+import cats.arrow.FunctionK
+import cats.data.Tuple2K
+import scala.util.Try
+import cats.~>
+
+import scala.compiletime.testing.*
+import scala.annotation.experimental
+
+@experimental
+class ApplyKSpec extends munit.FunSuite with Fixtures:
+  test("DeriveMacro should derive instance for a simple algebra") {
+    val applyK = Derive.applyK[SimpleService]
+    assert(applyK.isInstanceOf[ApplyK[SimpleService]])
+  }
+
+  test("ApplyK should be a valid instance for a simple algebra") {
+    val functorK = Derive.functorK[SimpleService]
+    val applyK = Derive.applyK[SimpleService]
+    val optionalInstance = functorK.mapK(instance)(FunctionK.lift([X] => (id: Id[X]) => Option(id)))
+
+    val fk: Tuple2K[Id, Option, *] ~> Try =
+      FunctionK.lift([X] => (tup: Tuple2K[Id, Option, X]) => Try(tup.second.map(_ => tup.first).get))
+    val tryInstance = applyK.map2K[Id, Option, Try](instance, optionalInstance)(fk)
+
+    assertEquals(tryInstance.id(), Try(instance.id()))
+    assertEquals(tryInstance.list(0), Try(instance.list(0)))
+    assertEquals(tryInstance.paranthesless, Try(instance.paranthesless))
+    assertEquals(tryInstance.tuple, Try(instance.tuple))
+  }
+
+  test("DeriveMacro should not derive instance for a not simple algebra") {
+    assert(typeCheckErrors("Derive.applyK[NotSimpleService]").isEmpty)
+  }
+
+  test("ApplyK derives syntax") {
+    val optionalInstance = instance.mapK(FunctionK.lift([X] => (id: Id[X]) => Option(id)))
+
+    val fk: Tuple2K[Id, Option, *] ~> Try =
+      FunctionK.lift([X] => (tup: Tuple2K[Id, Option, X]) => Try(tup.second.map(_ => tup.first).get))
+    val tryInstance = instance.map2K(optionalInstance)(fk)
+
+    assertEquals(tryInstance.id(), Try(instance.id()))
+    assertEquals(tryInstance.list(0), Try(instance.list(0)))
+    assertEquals(tryInstance.paranthesless, Try(instance.paranthesless))
+    assertEquals(tryInstance.tuple, Try(instance.tuple))
+  }

--- a/tests/src/test/scala-3/cats/tagless/tests/simple/Fixtures.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/simple/Fixtures.scala
@@ -24,7 +24,7 @@ import scala.annotation.experimental
 @experimental
 trait Fixtures:
   /** Simple algebra definition */
-  trait SimpleService[F[_]] derives FunctorK, SemigroupalK:
+  trait SimpleService[F[_]] derives FunctorK, SemigroupalK, InvariantK, ApplyK:
     def id(): F[Int]
     def list(id: Int): F[List[Int]]
     def lists(id1: Int, id2: Int): F[List[Int]]


### PR DESCRIPTION
This PR adds ApplyK as well as makes SemigroupalK macro a bit smarter and it may work now with type constructors in the func args.

- **ApplyK**
  - [x] `A => F[_]` functions support 
  - [ ] Varargs
    - [ ]  `AlgWithVarArgsParameter`