### PR TITLE
Hacky solution of the Tuple2K problem

### DIFF
--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -37,7 +37,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
     List(Flags.Final, Flags.Artifact, Flags.Synthetic, Flags.Mutable, Flags.Param)
 
   extension (xf: Transform)
-    private def transformRepeated(method: Symbol, tpe: TypeRepr, arg: Term): Tree =
+    def transformRepeated(method: Symbol, tpe: TypeRepr, arg: Term): Tree =
       val x = Symbol.freshName("x")
       val resultType = xf(tpe, Select.unique(arg, "head")).tpe
       val lambdaType = MethodType(x :: Nil)(_ => tpe :: Nil, _ => resultType)
@@ -46,7 +46,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
       val repeatedType = AppliedType(defn.RepeatedParamClass.typeRef, resultType :: Nil)
       Typed(result, TypeTree.of(using repeatedType.asType))
 
-    private def transformArg(method: Symbol, paramAndArg: (Definition, Tree)): Tree =
+    def transformArg(method: Symbol, paramAndArg: (Definition, Tree)): Tree =
       paramAndArg match
         case (param: ValDef, arg: Term) =>
           val paramType = param.tpt.tpe.widenParam

--- a/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
@@ -32,9 +32,6 @@ import scala.annotation.experimental
 class autoApplyKTests extends CatsTaglessTestSuite:
   import cats.tagless.tests.autoApplyKTests.AutoApplyKTestAlg
 
-  // Type inference limitation.
-  implicit val eqTuple3K: Eq[AutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ]] =
-    AutoApplyKTestAlg.eqForAutoApplyKTestAlg[Tuple3K[Try, Option, List]#λ]
   checkAll("ApplyK[AutoApplyKTestAlg]", ApplyKTests[AutoApplyKTestAlg].applyK[Try, Option, List, Int])
   checkAll("ApplyK is Serializable", SerializableTests.serializable(ApplyK[AutoApplyKTestAlg]))
 
@@ -42,8 +39,7 @@ object autoApplyKTests:
 
   trait AutoApplyKTestAlg[F[_]] derives ApplyK:
     def parseInt(str: String): F[Int]
-    // TODO: Macro should handle it
-    // def parseDouble(str: String): EitherT[F, String, Double]
+    def parseDouble(str: String): EitherT[F, String, Double]
     def divide(dividend: Float, divisor: Float): F[Float]
 
   object AutoApplyKTestAlg:
@@ -54,7 +50,7 @@ object autoApplyKTests:
         eqFf: Eq[F[Float]],
         eqEfd: Eq[EitherT[F, String, Double]]
     ): Eq[AutoApplyKTestAlg[F]] = Eq.by { algebra =>
-      (algebra.parseInt, /*algebra.parseDouble,*/ algebra.divide)
+      (algebra.parseInt, algebra.parseDouble, algebra.divide)
     }
 
     implicit def arbitraryAutoApplyKTestAlg[F[_]](implicit


### PR DESCRIPTION
Substitute `Tuple2K` with a type alias that picks the first type.