### PR TITLE
Consolidate Derive API between Scala 2 and Scala 3

### DIFF
--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package cats.tagless.derived
+package cats.tagless
 
-import cats.tagless.{ContravariantK, Derive}
+import cats.tagless.*
+import cats.tagless.macros.*
 
 import scala.annotation.experimental
 
-trait DerivedContravariantK:
-  @experimental inline def derived[Alg[_[_]]]: ContravariantK[Alg] = Derive.contravariantK[Alg]
+object Derive:
+  @experimental inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
+  @experimental inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
+  @experimental inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]
+  @experimental inline def applyK[Alg[_[_]]]: ApplyK[Alg] = MacroApplyK.derive[Alg]
+  @experimental inline def contravariantK[Alg[_[_]]]: ContravariantK[Alg] = MacroContravariantK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/DerivedApplyK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedApplyK.scala
@@ -16,8 +16,9 @@
 
 package cats.tagless.derived
 
-import cats.tagless.macros.Derive
+import cats.tagless.{ApplyK, Derive}
+
 import scala.annotation.experimental
 
 trait DerivedApplyK:
-  @experimental inline def derived[Alg[_[_]]] = Derive.applyK[Alg]
+  @experimental inline def derived[Alg[_[_]]]: ApplyK[Alg] = Derive.applyK[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/DerivedFunctorK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedFunctorK.scala
@@ -16,8 +16,9 @@
 
 package cats.tagless.derived
 
-import cats.tagless.macros.Derive
+import cats.tagless.{Derive, FunctorK}
+
 import scala.annotation.experimental
 
 trait DerivedFunctorK:
-  @experimental inline def derived[Alg[_[_]]] = Derive.functorK[Alg]
+  @experimental inline def derived[Alg[_[_]]]: FunctorK[Alg] = Derive.functorK[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/DerivedInvariantK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedInvariantK.scala
@@ -16,8 +16,9 @@
 
 package cats.tagless.derived
 
-import cats.tagless.macros.Derive
+import cats.tagless.{Derive, InvariantK}
+
 import scala.annotation.experimental
 
 trait DerivedInvariantK:
-  @experimental inline def derived[Alg[_[_]]] = Derive.invariantK[Alg]
+  @experimental inline def derived[Alg[_[_]]]: InvariantK[Alg] = Derive.invariantK[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/DerivedSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/DerivedSemigroupalK.scala
@@ -16,8 +16,9 @@
 
 package cats.tagless.derived
 
-import cats.tagless.macros.Derive
+import cats.tagless.{Derive, SemigroupalK}
+
 import scala.annotation.experimental
 
 trait DerivedSemigroupalK:
-  @experimental inline def derived[Alg[_[_]]] = Derive.semigroupalK[Alg]
+  @experimental inline def derived[Alg[_[_]]]: SemigroupalK[Alg] = Derive.semigroupalK[Alg]

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -108,11 +108,11 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
       def combineDef(method: DefDef)(argss: List[List[Tree]]): Option[Term] =
         val delegates = terms
           .lazyZip(args)
-          .map: (term, argst) =>
+          .map: (term, xf) =>
             term.call(method.symbol):
               for (params, args) <- method.paramss.zip(argss)
               yield for paramAndArg <- params.params.zip(args)
-              yield argst.transformArg(method.symbol, paramAndArg)
+              yield xf.transformArg(method.symbol, paramAndArg)
         Some(body.applyOrElse((method.returnTpt.tpe, delegates), _ => delegates.head))
 
       def combineVal(value: ValDef): Option[Term] =
@@ -188,3 +188,5 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
 
     def summonLambda[T <: AnyKind: Type](arg: Symbol, args: Symbol*): Term =
       TypeRepr.of[T].appliedTo(tpe.lambda(arg :: args.toList)).summon
+
+end DeriveMacros

--- a/core/src/main/scala-3/cats/tagless/macros/MacroApplyK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroApplyK.scala
@@ -17,11 +17,20 @@
 package cats.tagless.macros
 
 import cats.tagless.*
-import scala.annotation.experimental
+import cats.~>
+import cats.data.Tuple2K
 
-object Derive:
-  @experimental inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
-  @experimental inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
-  @experimental inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]
-  @experimental inline def applyK[Alg[_[_]]]: ApplyK[Alg] = MacroApplyK.derive[Alg]
-  @experimental inline def contravariantK[Alg[_[_]]]: ContravariantK[Alg] = MacroContravariantK.derive[Alg]
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroApplyK:
+  inline def derive[Alg[_[_]]] = ${ applyK[Alg] }
+
+  def applyK[Alg[_[_]]: Type](using Quotes): Expr[ApplyK[Alg]] = '{
+    new ApplyK[Alg]:
+      def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] =
+        ${ MacroFunctorK.deriveMapK('{ af }, '{ fk }) }
+      def productK[F[_], G[_]](af: Alg[F], ag: Alg[G]): Alg[Tuple2K[F, G, *]] =
+        ${ MacroSemigroupalK.deriveProductK('{ af }, '{ ag }) }
+  }

--- a/core/src/main/scala-3/cats/tagless/macros/MacroContravariantK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroContravariantK.scala
@@ -29,10 +29,10 @@ object MacroContravariantK:
   def contramapK[Alg[_[_]]: Type](using Quotes): Expr[ContravariantK[Alg]] = '{
     new ContravariantK[Alg]:
       def contramapK[F[_], G[_]](af: Alg[F])(fk: G ~> F): Alg[G] =
-        ${ deriveContramapK('af, 'fk) }
+        ${ deriveContramapK('{ af }, '{ fk }) }
   }
 
-  def deriveContramapK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
+  private[macros] def deriveContramapK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
       alg: Expr[Alg[F]],
       fk: Expr[G ~> F]
   )(using q: Quotes): Expr[Alg[G]] =

--- a/core/src/main/scala-3/cats/tagless/macros/MacroFunctorK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroFunctorK.scala
@@ -23,19 +23,18 @@ import scala.annotation.experimental
 import scala.quoted.*
 
 @experimental
-object MacroInvariantK:
-  inline def derive[Alg[_[_]]] = ${ invariantK[Alg] }
+object MacroFunctorK:
+  inline def derive[Alg[_[_]]] = ${ functorK[Alg] }
 
-  def invariantK[Alg[_[_]]: Type](using Quotes): Expr[InvariantK[Alg]] = '{
-    new InvariantK[Alg]:
-      def imapK[F[_], G[_]](alg: Alg[F])(fk: F ~> G)(gk: G ~> F): Alg[G] =
-        ${ deriveIMapK('alg, 'fk, 'gk) }
+  def functorK[Alg[_[_]]: Type](using Quotes): Expr[FunctorK[Alg]] = '{
+    new FunctorK[Alg]:
+      def mapK[F[_], G[_]](alg: Alg[F])(fk: F ~> G): Alg[G] =
+        ${ deriveMapK('{ alg }, '{ fk }) }
   }
 
-  def deriveIMapK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
+  private[macros] def deriveMapK[Alg[_[_]]: Type, F[_]: Type, G[_]: Type](
       alg: Expr[Alg[F]],
-      fk: Expr[F ~> G],
-      gk: Expr[G ~> F]
+      fk: Expr[F ~> G]
   )(using q: Quotes): Expr[Alg[G]] =
     import quotes.reflect.*
     given DeriveMacros[q.type] = new DeriveMacros
@@ -48,19 +47,17 @@ object MacroInvariantK:
       args = {
         case (tpe, arg) if tpe.contains(g) =>
           Select
-            .unique(tpe.summonLambda[InvariantK](g), "imapK")
+            .unique(tpe.summonLambda[ContravariantK](g), "contramapK")
             .appliedToTypes(List(G, F))
             .appliedTo(arg)
-            .appliedTo(gk.asTerm)
             .appliedTo(fk.asTerm)
       },
       body = {
         case (tpe, body) if tpe.contains(g) =>
           Select
-            .unique(tpe.summonLambda[InvariantK](g), "imapK")
+            .unique(tpe.summonLambda[FunctorK](g), "mapK")
             .appliedToTypes(List(F, G))
             .appliedTo(body)
             .appliedTo(fk.asTerm)
-            .appliedTo(gk.asTerm)
       }
     )

--- a/tests/src/test/scala-2/cats/tagless/tests/experimental.scala
+++ b/tests/src/test/scala-2/cats/tagless/tests/experimental.scala
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-package cats.tagless.derived
+package cats.tagless.tests
 
-import cats.tagless.{ContravariantK, Derive}
-
-import scala.annotation.experimental
-
-trait DerivedContravariantK:
-  @experimental inline def derived[Alg[_[_]]]: ContravariantK[Alg] = Derive.contravariantK[Alg]
+/** Used to cross-compile with Scala 3. */
+class experimental extends scala.annotation.StaticAnnotation

--- a/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/TestAlgebras.scala
@@ -25,8 +25,8 @@ import cats.syntax.all.*
 import cats.{Eq, Eval, Monoid, ~>}
 import org.scalacheck.{Arbitrary, Cogen}
 
-import scala.util.Try
 import scala.annotation.experimental
+import scala.util.Try
 
 // TODO: @finalAlg @autoProductNK @autoInstrument
 @experimental
@@ -56,36 +56,35 @@ object SafeAlg:
 @experimental
 trait SafeInvAlg[F[_]] derives InvariantK, SemigroupalK:
   def parseInt(fs: F[String]): F[Int]
-  // def doubleParser(precision: Int): Kleisli[F, String, Double]
-  // def parseIntOrError(fs: EitherT[F, String, String]): F[Int]
+  def doubleParser(precision: Int): Kleisli[F, String, Double]
+  def parseIntOrError(fs: EitherT[F, String, String]): F[Int]
 
 object SafeInvAlg:
-  // import TestInstances.*
+  import TestInstances.*
 
   implicit def eqForSafeInvAlg[F[_]](implicit
       eqFi: Eq[F[Int]],
       eqFd: Eq[F[Double]],
       exFs: ExhaustiveCheck[F[String]],
       exEfs: ExhaustiveCheck[EitherT[F, String, String]]
-  ): Eq[SafeInvAlg[F]] = Eq.by { algebra =>
-    (algebra.parseInt /*, algebra.doubleParser, algebra.parseIntOrError*/ )
-  }
+  ): Eq[SafeInvAlg[F]] = Eq.by: algebra =>
+    (algebra.parseInt, algebra.doubleParser, algebra.parseIntOrError)
 
   implicit def arbitrarySafeInvAlg[F[_]](implicit
       coFs: Cogen[F[String]],
       coEfs: Cogen[EitherT[F, String, String]],
       arbFi: Arbitrary[F[Int]],
       arbFd: Arbitrary[F[Double]]
-  ): Arbitrary[SafeInvAlg[F]] = Arbitrary(
-    for
-      parseIntF <- Arbitrary.arbitrary[F[String] => F[Int]]
-      doubleParserF <- Arbitrary.arbitrary[Int => Kleisli[F, String, Double]]
-      parseIntOrErrorF <- Arbitrary.arbitrary[EitherT[F, String, String] => F[Int]]
-    yield new SafeInvAlg[F]:
-      def parseInt(fs: F[String]) = parseIntF(fs)
-      def doubleParser(precision: Int) = doubleParserF(precision)
-      def parseIntOrError(fs: EitherT[F, String, String]) = parseIntOrErrorF(fs)
+  ): Arbitrary[SafeInvAlg[F]] = Arbitrary(for
+    parseIntF <- Arbitrary.arbitrary[F[String] => F[Int]]
+    doubleParserF <- Arbitrary.arbitrary[Int => Kleisli[F, String, Double]]
+    parseIntOrErrorF <- Arbitrary.arbitrary[EitherT[F, String, String] => F[Int]]
+  yield new SafeInvAlg[F]:
+    def parseInt(fs: F[String]) = parseIntF(fs)
+    def doubleParser(precision: Int) = doubleParserF(precision)
+    def parseIntOrError(fs: EitherT[F, String, String]) = parseIntOrErrorF(fs)
   )
+
 @experimental
 trait CalculatorAlg[F[_]] derives InvariantK, SemigroupalK:
   def lit(i: Int): F[Int]
@@ -98,9 +97,8 @@ object CalculatorAlg:
   implicit def eqForCalculatorAlg[F[_]](implicit
       eqFi: Eq[F[Int]],
       exFi: ExhaustiveCheck[F[Int]]
-  ): Eq[CalculatorAlg[F]] = Eq.by { algebra =>
+  ): Eq[CalculatorAlg[F]] = Eq.by: algebra =>
     (algebra.lit, algebra.add, algebra.show[Int])
-  }
 
   implicit def arbitraryCalculatorAlg[F[_]](implicit
       coFi: Cogen[F[Int]],

--- a/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoApplyKTests.scala
@@ -25,12 +25,12 @@ import cats.laws.discipline.eq.*
 import cats.tagless.laws.discipline.ApplyKTests
 import org.scalacheck.Arbitrary
 
-import scala.util.Try
 import scala.annotation.experimental
+import scala.util.Try
 
 @experimental
 class autoApplyKTests extends CatsTaglessTestSuite:
-  import cats.tagless.tests.autoApplyKTests.AutoApplyKTestAlg
+  import autoApplyKTests.AutoApplyKTestAlg
 
   checkAll("ApplyK[AutoApplyKTestAlg]", ApplyKTests[AutoApplyKTestAlg].applyK[Try, Option, List, Int])
   checkAll("ApplyK is Serializable", SerializableTests.serializable(ApplyK[AutoApplyKTestAlg]))
@@ -49,24 +49,22 @@ object autoApplyKTests:
         eqFi: Eq[F[Int]],
         eqFf: Eq[F[Float]],
         eqEfd: Eq[EitherT[F, String, Double]]
-    ): Eq[AutoApplyKTestAlg[F]] = Eq.by { algebra =>
+    ): Eq[AutoApplyKTestAlg[F]] = Eq.by: algebra =>
       (algebra.parseInt, algebra.parseDouble, algebra.divide)
-    }
 
     implicit def arbitraryAutoApplyKTestAlg[F[_]](implicit
         arbFi: Arbitrary[F[Int]],
         arbFf: Arbitrary[F[Float]],
         arbEfd: Arbitrary[EitherT[F, String, Double]]
-    ): Arbitrary[AutoApplyKTestAlg[F]] = Arbitrary {
-      for
-        pInt <- Arbitrary.arbitrary[String => F[Int]]
-        pDouble <- Arbitrary.arbitrary[String => EitherT[F, String, Double]]
-        div <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
-      yield new AutoApplyKTestAlg[F]:
-        def parseInt(str: String) = pInt(str)
-        def parseDouble(str: String) = pDouble(str)
-        def divide(dividend: Float, divisor: Float) = div(dividend, divisor)
-    }
+    ): Arbitrary[AutoApplyKTestAlg[F]] = Arbitrary(for
+      pInt <- Arbitrary.arbitrary[String => F[Int]]
+      pDouble <- Arbitrary.arbitrary[String => EitherT[F, String, Double]]
+      div <- Arbitrary.arbitrary[(Float, Float) => F[Float]]
+    yield new AutoApplyKTestAlg[F]:
+      def parseInt(str: String) = pInt(str)
+      def parseDouble(str: String) = pDouble(str)
+      def divide(dividend: Float, divisor: Float) = div(dividend, divisor)
+    )
 
   trait AlgWithVarArgsParameter[F[_]] derives ApplyK:
     def sum(xs: Int*): Int

--- a/tests/src/test/scala-3/cats/tagless/tests/autoContravariantKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoContravariantKTests.scala
@@ -16,19 +16,17 @@
 
 package cats.tagless.tests
 
-import cats.tagless.*
 import cats.Eq
 import cats.data.Cokleisli
 import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary.*
 import cats.laws.discipline.eq.*
-import cats.tagless.ContravariantK
+import cats.tagless.*
 import cats.tagless.laws.discipline.ContravariantKTests
 import org.scalacheck.{Arbitrary, Cogen}
 
-import scala.util.Try
 import scala.annotation.experimental
-import cats.tagless.macros.Derive.contravariantK
+import scala.util.Try
 
 @experimental
 class autoContravariantKTests extends CatsTaglessTestSuite:
@@ -47,7 +45,7 @@ object autoContravariantKTests:
 
   object TestAlgebra:
     implicit def eqv[F[_]](implicit arbFi: Arbitrary[F[Int]], arbFs: Arbitrary[F[String]]): Eq[TestAlgebra[F]] =
-      Eq.by(algebra => (algebra.sum /*, algebra.sumAll*/, algebra.foldSpecialized))
+      Eq.by(algebra => (algebra.sum, algebra.sumAll _, algebra.foldSpecialized))
 
   implicit def arbitrary[F[_]](implicit
       arbFs: Arbitrary[F[String]],

--- a/tests/src/test/scala-3/cats/tagless/tests/autoFunctorKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoFunctorKTests.scala
@@ -33,17 +33,16 @@
 package cats.tagless
 package tests
 
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.Derive
-import cats.{Monad, Show, ~>}
 import cats.arrow.FunctionK
+import cats.data.Cokleisli
 import cats.free.Free
 import cats.laws.discipline.SerializableTests
 import cats.tagless.laws.discipline.FunctorKTests
+import cats.tagless.syntax.all.*
+import cats.{Monad, Show, ~>}
 
-import scala.util.Try
-import cats.data.Cokleisli
 import scala.annotation.experimental
+import scala.util.Try
 
 @experimental
 class autoFunctorKTests extends CatsTaglessTestSuite:

--- a/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoInvariantKTests.scala
@@ -17,14 +17,14 @@
 package cats.tagless
 package tests
 
-import cats.tagless.syntax.all.*
-import cats.~>
 import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary.*
 import cats.tagless.laws.discipline.InvariantKTests
+import cats.tagless.syntax.all.*
+import cats.~>
 
-import scala.util.Try
 import scala.annotation.experimental
+import scala.util.Try
 
 @experimental
 class autoInvariantKTests extends CatsTaglessTestSuite:

--- a/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalKTests.scala
@@ -22,8 +22,8 @@ import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary.*
 import cats.tagless.laws.discipline.SemigroupalKTests
 
-import scala.util.Try
 import scala.annotation.experimental
+import scala.util.Try
 
 @experimental
 class autoSemigroupalKTests extends CatsTaglessTestSuite:

--- a/tests/src/test/scala-3/cats/tagless/tests/experimental.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/experimental.scala
@@ -14,23 +14,7 @@
  * limitations under the License.
  */
 
-package cats.tagless.macros
+package cats.tagless.tests
 
-import cats.tagless.*
-import cats.~>
-import cats.data.Tuple2K
-
-import scala.annotation.experimental
-import scala.quoted.*
-
-@experimental
-object MacroApplyK:
-  inline def derive[Alg[_[_]]] = ${ applyK[Alg] }
-
-  def applyK[Alg[_[_]]: Type](using Quotes): Expr[ApplyK[Alg]] = '{
-    new ApplyK[Alg]:
-      def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] =
-        ${ MacroFunctorK.deriveMapK('af, 'fk) }
-      def productK[F[_], G[_]](af: Alg[F], ag: Alg[G]): Alg[Tuple2K[F, G, *]] =
-        ${ MacroSemigroupalK.deriveProductK('af, 'ag) }
-  }
+/** Used to cross-compile with Scala 2. */
+class experimental extends scala.annotation.experimental

--- a/tests/src/test/scala/cats/tagless/tests/simple/ApplyKSpec.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/ApplyKSpec.scala
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
-
-import cats.tagless.*
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.*
+package cats.tagless
+package tests.simple
 
 import cats.Id
-import cats.arrow.FunctionK
 import cats.data.Tuple2K
-import scala.util.Try
-import cats.~>
+import cats.tagless.syntax.all.*
+import cats.tagless.tests.experimental
 
-import scala.compiletime.testing.*
-import scala.annotation.experimental
+import scala.util.Try
 
 @experimental
-class ApplyKSpec extends munit.FunSuite with Fixtures:
+class ApplyKSpec extends munit.FunSuite with Fixtures {
   test("DeriveMacro should derive instance for a simple algebra") {
     val applyK = Derive.applyK[SimpleService]
     assert(applyK.isInstanceOf[ApplyK[SimpleService]])
@@ -39,10 +34,8 @@ class ApplyKSpec extends munit.FunSuite with Fixtures:
   test("ApplyK should be a valid instance for a simple algebra") {
     val functorK = Derive.functorK[SimpleService]
     val applyK = Derive.applyK[SimpleService]
-    val optionalInstance = functorK.mapK(instance)(FunctionK.lift([X] => (id: Id[X]) => Option(id)))
-
-    val fk: Tuple2K[Id, Option, *] ~> Try =
-      FunctionK.lift([X] => (tup: Tuple2K[Id, Option, X]) => Try(tup.second.map(_ => tup.first).get))
+    val optionalInstance = functorK.mapK(instance)(FunctionKLift[Id, Option](Option.apply))
+    val fk = FunctionKLift[Tuple2K[Id, Option, *], Try](tup => Try(tup.second.map(_ => tup.first).get))
     val tryInstance = applyK.map2K[Id, Option, Try](instance, optionalInstance)(fk)
 
     assertEquals(tryInstance.id(), Try(instance.id()))
@@ -52,14 +45,12 @@ class ApplyKSpec extends munit.FunSuite with Fixtures:
   }
 
   test("DeriveMacro should derive instance for a not simple algebra") {
-    assert(typeCheckErrors("Derive.applyK[NotSimpleService]").isEmpty)
+    assert(compileErrors("Derive.applyK[NotSimpleService]").isEmpty)
   }
 
   test("ApplyK derives syntax") {
-    val optionalInstance = instance.mapK(FunctionK.lift([X] => (id: Id[X]) => Option(id)))
-
-    val fk: Tuple2K[Id, Option, *] ~> Try =
-      FunctionK.lift([X] => (tup: Tuple2K[Id, Option, X]) => Try(tup.second.map(_ => tup.first).get))
+    val optionalInstance = instance.mapK(FunctionKLift[Id, Option](Option.apply))
+    val fk = FunctionKLift[Tuple2K[Id, Option, *], Try](tup => Try(tup.second.map(_ => tup.first).get))
     val tryInstance = instance.map2K(optionalInstance)(fk)
 
     assertEquals(tryInstance.id(), Try(instance.id()))
@@ -67,3 +58,4 @@ class ApplyKSpec extends munit.FunSuite with Fixtures:
     assertEquals(tryInstance.paranthesless, Try(instance.paranthesless))
     assertEquals(tryInstance.tuple, Try(instance.tuple))
   }
+}

--- a/tests/src/test/scala/cats/tagless/tests/simple/ContravariantKSpec.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/ContravariantKSpec.scala
@@ -14,32 +14,27 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
-
-import cats.tagless.*
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.*
+package cats.tagless
+package tests.simple
 
 import cats.Id
-import cats.arrow.FunctionK
-import cats.~>
-
-import scala.compiletime.testing.*
-import scala.annotation.experimental
+import cats.tagless.syntax.all.*
+import cats.tagless.tests.experimental
 
 @experimental
-class ContravariantKSpec extends munit.FunSuite with Fixtures:
+class ContravariantKSpec extends munit.FunSuite with Fixtures {
 
   test("DeriveMacro should derive instance for a simple algebra") {
     def contravariantK = Derive.contravariantK[SimpleServiceC]
+
     assert(contravariantK.isInstanceOf[ContravariantK[SimpleServiceC]])
   }
 
   test("DeriveMacro should derive instance for a simple algebra #2") {
     def contravariantK = Derive.contravariantK[SimpleServiceC]
-    val fk: Option ~> Id = FunctionK.lift[Option, Id]([X] => (id: Option[X]) => id.get)
-    val optionalInstance = contravariantK.contramapK(instancec)(fk)
 
+    val fk = FunctionKLift[Option, Id](_.get)
+    val optionalInstance = contravariantK.contramapK(instancec)(fk)
     val f: (Int, String) => Int = (i, s) => i + s.toInt
 
     assertEquals(optionalInstance.id(Some(23)), instancec.id(23))
@@ -48,16 +43,16 @@ class ContravariantKSpec extends munit.FunSuite with Fixtures:
   }
 
   test("DeriveMacro should not derive instance for not a contravariant algebra") {
-    assert(typeCheckErrors("Derive.contravariantK[SimpleService]").nonEmpty)
+    assert(compileErrors("Derive.contravariantK[SimpleService]").nonEmpty)
   }
 
   test("ContravariantK derives syntax") {
-    val fk: Option ~> Id = FunctionK.lift[Option, Id]([X] => (id: Option[X]) => id.get)
+    val fk = FunctionKLift[Option, Id](_.get)
     val optionalInstance = instancec.contramapK(fk)
-
     val f: (Int, String) => Int = (i, s) => i + s.toInt
 
     assertEquals(optionalInstance.id(Some(23)), instancec.id(23))
     assertEquals(optionalInstance.ids(Some(0), Some(1)), instancec.ids(0, 1))
     assertEquals(optionalInstance.foldSpecialized("0")(f).run(Some("1")), instancec.foldSpecialized("0")(f).run("1"))
   }
+}

--- a/tests/src/test/scala/cats/tagless/tests/simple/Fixtures.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/Fixtures.scala
@@ -14,47 +14,64 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
+package cats.tagless
+package tests.simple
 
-import cats.tagless.*
 import cats.Id
 import cats.data.Cokleisli
-import scala.annotation.experimental
+import cats.tagless.tests.experimental
 
-@experimental
-trait Fixtures:
+object Fixtures extends Fixtures
+@experimental trait Fixtures {
+
   /** Simple algebra definition */
-  trait SimpleService[F[_]] derives FunctorK, SemigroupalK, InvariantK, ApplyK:
+  trait SimpleService[F[_]] {
     def id(): F[Int]
     def list(id: Int): F[List[Int]]
     def lists(id1: Int, id2: Int): F[List[Int]]
     def paranthesless: F[Int]
     def tuple: F[(Int, Long)]
+  }
 
-  object instance extends SimpleService[Id]:
+  object SimpleService {
+    implicit val functorK: FunctorK[SimpleService] = Derive.functorK
+    implicit val invariantK: InvariantK[SimpleService] = Derive.invariantK
+    implicit val semigroupalK: SemigroupalK[SimpleService] = Derive.semigroupalK
+    implicit val applyK: ApplyK[SimpleService] = Derive.applyK
+  }
+
+  object instance extends SimpleService[Id] {
     def id(): Id[Int] = 42
     def list(id: Int): Id[List[Int]] = List(id)
     def lists(id1: Int, id2: Int): Id[List[Int]] = List(id1, id2)
     def paranthesless: Id[Int] = 23
     def tuple: Id[(Int, Long)] = (42, 23)
+  }
 
-  trait NotSimpleService[F[_]]:
+  trait NotSimpleService[F[_]] {
     def id(): Int
     def list(id: Int): F[List[Int]]
+  }
 
-  object instancens extends NotSimpleService[Id]:
+  object instancens extends NotSimpleService[Id] {
     def id(): Int = 42
     def list(id: Int): Id[List[Int]] = List(1, 2, 3)
+  }
 
-  trait SimpleServiceC[F[_]] derives ContravariantK:
+  trait SimpleServiceC[F[_]] {
     def id(id: F[Int]): Int
     def ids(id1: F[Int], id2: F[Int]): Int
     def foldSpecialized(init: String)(f: (Int, String) => Int): Cokleisli[F, String, Int]
+  }
 
-  object instancec extends SimpleServiceC[Id]:
+  object SimpleServiceC {
+    implicit val contravariantK: ContravariantK[SimpleServiceC] = Derive.contravariantK
+  }
+
+  object instancec extends SimpleServiceC[Id] {
     def id(id: Id[Int]): Int = id
     def ids(id1: Id[Int], id2: Id[Int]): Int = id1 + id2
     def foldSpecialized(init: String)(f: (Int, String) => Int): Cokleisli[Id, String, Int] =
       Cokleisli.apply((str: Id[String]) => f(init.toInt, str))
-
-object Fixtures extends Fixtures
+  }
+}

--- a/tests/src/test/scala/cats/tagless/tests/simple/FunctorKSpec.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/FunctorKSpec.scala
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
-
-import cats.tagless.*
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.*
+package cats.tagless
+package tests.simple
 
 import cats.Id
-import cats.arrow.FunctionK
-
-import scala.compiletime.testing.*
-import scala.annotation.experimental
+import cats.tagless.syntax.all.*
+import cats.tagless.tests.experimental
 
 @experimental
-class FunctorKSpec extends munit.FunSuite with Fixtures:
+class FunctorKSpec extends munit.FunSuite with Fixtures {
 
   test("DeriveMacro should derive instance for a simple algebra") {
     val functorK = Derive.functorK[SimpleService]
@@ -36,8 +31,7 @@ class FunctorKSpec extends munit.FunSuite with Fixtures:
 
   test("FunctorK should be a valid instance for a simple algebra") {
     val functorK = Derive.functorK[SimpleService]
-
-    val optionalInstance = functorK.mapK(instance)(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val optionalInstance = functorK.mapK(instance)(FunctionKLift[Id, Option](Option.apply))
 
     assertEquals(optionalInstance.id(), Some(instance.id()))
     assertEquals(optionalInstance.list(0), Some(instance.list(0)))
@@ -47,11 +41,11 @@ class FunctorKSpec extends munit.FunSuite with Fixtures:
   }
 
   test("DeriveMacro should derive instance for a not simple algebra") {
-    assert(typeCheckErrors("Derive.functorK[NotSimpleService]").isEmpty)
+    assert(compileErrors("Derive.functorK[NotSimpleService]").isEmpty)
   }
 
   test("FunctorK derives syntax") {
-    val optionalInstance = instance.mapK(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val optionalInstance = instance.mapK(FunctionKLift[Id, Option](Option.apply))
 
     assertEquals(optionalInstance.id(), Some(instance.id()))
     assertEquals(optionalInstance.list(0), Some(instance.list(0)))
@@ -59,3 +53,4 @@ class FunctorKSpec extends munit.FunSuite with Fixtures:
     assertEquals(optionalInstance.paranthesless, Some(instance.paranthesless))
     assertEquals(optionalInstance.tuple, Some(instance.tuple))
   }
+}

--- a/tests/src/test/scala/cats/tagless/tests/simple/InvariantKSpec.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/InvariantKSpec.scala
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
-
-import cats.tagless.*
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.*
+package cats.tagless
+package tests.simple
 
 import cats.Id
-import cats.arrow.FunctionK
-import cats.~>
-
-import scala.compiletime.testing.*
-import scala.annotation.experimental
+import cats.tagless.syntax.all.*
+import cats.tagless.tests.experimental
 
 @experimental
-class InvariantKSpec extends munit.FunSuite with Fixtures:
+class InvariantKSpec extends munit.FunSuite with Fixtures {
   test("DeriveMacro should derive instance for a simple algebra") {
     val invariantK = Derive.invariantK[SimpleService]
     assert(invariantK.isInstanceOf[InvariantK[SimpleService]])
@@ -37,9 +31,8 @@ class InvariantKSpec extends munit.FunSuite with Fixtures:
   test("InvariantK should be a valid instance for a simple algebra") {
     val invariantK = Derive.invariantK[SimpleService]
     val functorK = Derive.functorK[SimpleService]
-
-    val fk: Id ~> Option = FunctionK.lift([X] => (id: Id[X]) => Option(id))
-    val gk: Option ~> Id = FunctionK.lift([X] => (id: Option[X]) => id.get)
+    val fk = FunctionKLift[Id, Option](Option.apply)
+    val gk = FunctionKLift[Option, Id](_.get)
     val invariantInstance = invariantK.imapK(instance)(fk)(gk)
     val optionalInstance = functorK.mapK(instance)(fk)
 
@@ -51,12 +44,12 @@ class InvariantKSpec extends munit.FunSuite with Fixtures:
   }
 
   test("DeriveMacro should derive instance for a not simple algebra") {
-    assert(typeCheckErrors("Derive.invariantK[NotSimpleService]").isEmpty)
+    assert(compileErrors("Derive.invariantK[NotSimpleService]").isEmpty)
   }
 
   test("InvariantK derives syntax") {
-    val fk: Id ~> Option = FunctionK.lift([X] => (id: Id[X]) => Option(id))
-    val gk: Option ~> Id = FunctionK.lift([X] => (id: Option[X]) => id.get)
+    val fk = FunctionKLift[Id, Option](Option.apply)
+    val gk = FunctionKLift[Option, Id](_.get)
     val invariantInstance = instance.imapK(fk)(gk)
     val optionalInstance = instance.mapK(fk)
 
@@ -66,3 +59,4 @@ class InvariantKSpec extends munit.FunSuite with Fixtures:
     assertEquals(invariantInstance.paranthesless, optionalInstance.paranthesless)
     assertEquals(invariantInstance.tuple, optionalInstance.tuple)
   }
+}

--- a/tests/src/test/scala/cats/tagless/tests/simple/SemigroupalKSpec.scala
+++ b/tests/src/test/scala/cats/tagless/tests/simple/SemigroupalKSpec.scala
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package cats.tagless.simple
-
-import cats.tagless.*
-import cats.tagless.syntax.all.*
-import cats.tagless.macros.*
+package cats.tagless
+package tests.simple
 
 import cats.Id
-import cats.arrow.FunctionK
 import cats.data.Tuple2K
-
-import scala.annotation.experimental
+import cats.tagless.syntax.all.*
+import cats.tagless.tests.experimental
 
 @experimental
-class SemigroupalKSpec extends munit.FunSuite with Fixtures:
+class SemigroupalKSpec extends munit.FunSuite with Fixtures {
   test("DeriveMacro should derive instance for a simple algebra") {
     val semigroupalK = Derive.semigroupalK[SimpleService]
     assert(semigroupalK.isInstanceOf[SemigroupalK[SimpleService]])
   }
 
-  test("SemigorupalK should be a valid instance for a simple algebra") {
+  test("SemigroupalK should be a valid instance for a simple algebra") {
     val functorK = Derive.functorK[SimpleService]
     val semigroupalK = Derive.semigroupalK[SimpleService]
-    val optionalInstance = functorK.mapK(instance)(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val optionalInstance = functorK.mapK(instance)(FunctionKLift[Id, Option](Option.apply))
     val combinedInstance = semigroupalK.productK(instance, optionalInstance)
 
     assertEquals(combinedInstance.id(), Tuple2K(instance.id(), optionalInstance.id()))
@@ -54,7 +50,7 @@ class SemigroupalKSpec extends munit.FunSuite with Fixtures:
   }
 
   test("SemigroupalK derives syntax") {
-    val optionalInstance = instance.mapK(FunctionK.lift([X] => (id: Id[X]) => Some(id)))
+    val optionalInstance = instance.mapK(FunctionKLift[Id, Option](Option.apply))
     val combinedInstance = instance.productK(optionalInstance)
 
     assertEquals(combinedInstance.id(), Tuple2K(instance.id(), optionalInstance.id()))
@@ -63,3 +59,4 @@ class SemigroupalKSpec extends munit.FunSuite with Fixtures:
     assertEquals(combinedInstance.paranthesless, Tuple2K(instance.paranthesless, optionalInstance.paranthesless))
     assertEquals(combinedInstance.tuple, Tuple2K(instance.tuple, optionalInstance.tuple))
   }
+}


### PR DESCRIPTION
 * Move classes around to the correct place
 * Add `experimental` annotation to Scala 2 for testing
 * Move simple tests to shared
 * Fix a bug in Scala 2 `SemigroupalK` derivation