### PR TITLE
[Scala 3] Add derivation for Contravariant and Invariant

### DIFF
--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -16,7 +16,7 @@
 
 package cats.tagless
 
-import cats.Functor
+import cats.{Functor, Contravariant}
 import cats.tagless.*
 import cats.tagless.macros.*
 
@@ -25,6 +25,7 @@ import scala.annotation.experimental
 @experimental
 object Derive:
   inline def functor[F[_]]: Functor[F] = MacroFunctor.derive[F]
+  inline def contravariant[F[_]]: Contravariant[F] = MacroContravariant.derive[F]
   inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
   inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
   inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -16,7 +16,7 @@
 
 package cats.tagless
 
-import cats.{Functor, Contravariant}
+import cats.*
 import cats.tagless.*
 import cats.tagless.macros.*
 
@@ -26,6 +26,7 @@ import scala.annotation.experimental
 object Derive:
   inline def functor[F[_]]: Functor[F] = MacroFunctor.derive[F]
   inline def contravariant[F[_]]: Contravariant[F] = MacroContravariant.derive[F]
+  inline def invariant[F[_]]: Invariant[F] = MacroInvariant.derive[F]
   inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]
   inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive[Alg]
   inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/package.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/package.scala
@@ -16,10 +16,11 @@
 
 package cats.tagless.derived
 
-import cats.{Functor, Contravariant}
+import cats.*
 import cats.tagless.Derive
 
 import scala.annotation.experimental
 
 extension (x: Functor.type) @experimental inline def derived[F[_]]: Functor[F] = Derive.functor
 extension (x: Contravariant.type) @experimental inline def derived[F[_]]: Contravariant[F] = Derive.contravariant
+extension (x: Invariant.type) @experimental inline def derived[F[_]]: Invariant[F] = Derive.invariant

--- a/core/src/main/scala-3/cats/tagless/derived/package.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/package.scala
@@ -16,9 +16,10 @@
 
 package cats.tagless.derived
 
-import cats.Functor
+import cats.{Functor, Contravariant}
 import cats.tagless.Derive
 
 import scala.annotation.experimental
 
 extension (x: Functor.type) @experimental inline def derived[F[_]]: Functor[F] = Derive.functor
+extension (x: Contravariant.type) @experimental inline def derived[F[_]]: Contravariant[F] = Derive.contravariant

--- a/core/src/main/scala-3/cats/tagless/macros/MacroContravariant.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroContravariant.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.tagless.*
+import cats.{Functor, Contravariant}
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroContravariant:
+  inline def derive[F[_]] = ${ contramap[F] }
+
+  def contramap[F[_]: Type](using Quotes): Expr[Contravariant[F]] = '{
+    new Contravariant[F]:
+      def contramap[A, B](fa: F[A])(f: B => A): F[B] =
+        ${ deriveContramap('{ fa }, '{ f }) }
+  }
+
+  private[macros] def deriveContramap[F[_]: Type, A: Type, B: Type](
+      fa: Expr[F[A]],
+      f: Expr[B => A]
+  )(using q: Quotes): Expr[F[B]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val A = TypeRepr.of[A]
+    val B = TypeRepr.of[B]
+    val b = B.typeSymbol
+
+    fa.asTerm.transformTo[F[B]](
+      args = {
+        case (tpe, arg) if tpe.contains(b) =>
+          Select
+            .unique(tpe.summonLambda[Functor](b), "map")
+            .appliedToTypes(List(B, A))
+            .appliedTo(arg)
+            .appliedTo(f.asTerm)
+      },
+      body = {
+        case (tpe, body) if tpe.contains(b) =>
+          Select
+            .unique(tpe.summonLambda[Contravariant](b), "contramap")
+            .appliedToTypes(List(A, B))
+            .appliedTo(body)
+            .appliedTo(f.asTerm)
+      }
+    )

--- a/core/src/main/scala-3/cats/tagless/macros/MacroInvariant.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroInvariant.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.Invariant
+import cats.tagless.*
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroInvariant:
+  inline def derive[F[_]] = ${ invariant[F] }
+
+  def invariant[F[_]: Type](using Quotes): Expr[Invariant[F]] = '{
+    new Invariant[F]:
+      def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B] =
+        ${ deriveIMap('{ fa }, '{ f }, '{ g }) }
+  }
+
+  private[macros] def deriveIMap[F[_]: Type, A: Type, B: Type](
+      fa: Expr[F[A]],
+      f: Expr[A => B],
+      g: Expr[B => A]
+  )(using q: Quotes): Expr[F[B]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val A = TypeRepr.of[A]
+    val B = TypeRepr.of[B]
+    val b = B.typeSymbol
+
+    fa.asTerm.transformTo[F[B]](
+      args = {
+        case (tpe, arg) if tpe.contains(b) =>
+          Select
+            .unique(tpe.summonLambda[Invariant](b), "imap")
+            .appliedToTypes(List(B, A))
+            .appliedTo(arg)
+            .appliedTo(g.asTerm)
+            .appliedTo(f.asTerm)
+      },
+      body = {
+        case (tpe, body) if tpe.contains(b) =>
+          Select
+            .unique(tpe.summonLambda[Invariant](b), "imap")
+            .appliedToTypes(List(A, B))
+            .appliedTo(body)
+            .appliedTo(f.asTerm)
+            .appliedTo(g.asTerm)
+      }
+    )

--- a/tests/src/test/scala-3/cats/tagless/tests/autoContravariantTest.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoContravariantTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.{Contravariant, Eq}
+import cats.laws.discipline.{ContravariantTests, ExhaustiveCheck, SerializableTests}
+import cats.laws.discipline.eq.*
+import cats.tagless.derived.*
+import org.scalacheck.{Arbitrary, Cogen}
+
+@experimental
+class autoContravariantTests extends CatsTaglessTestSuite:
+  import autoContravariantTest.*
+
+  checkAll("Contravariant[SimpleAlg]", ContravariantTests[SimpleAlg].contravariant[Float, String, Int])
+  checkAll("Contravariant is Serializable", SerializableTests.serializable(Contravariant[SimpleAlg]))
+
+  test("non effect method correctly delegated"):
+    val doubleAlg: AlgWithNonEffectMethod[String] = AlgWithNonEffectMethodFloat.contramap[String](_.toFloat)
+    assertEquals(doubleAlg.foo2("big"), "gib")
+    assertEquals(doubleAlg.foo3("3"), "3")
+
+  test("extra type param correctly handled"):
+    val doubleAlg: AlgWithExtraTypeParam[String, String] = AlgWithExtraTypeParamFloat.contramap[String](_.toFloat)
+    assertEquals(doubleAlg.foo("big", "3"), 6)
+
+  test("Alg with non effect method with default Impl"):
+    val intAlg = new AlgWithDefaultImpl[Int]:
+      def plusOne(i: Int): Int = i + 1
+
+    assertEquals(intAlg.contramap[String](_.toInt).plusOne("3"), 4)
+    assertEquals(intAlg.contramap[String](_.toInt).minusOne(2), 1)
+
+@experimental
+object autoContravariantTest:
+
+  trait SimpleAlg[T] derives Contravariant:
+    def foo(t: T): String
+    def bar(opt: Option[T]): String
+
+  trait AlgWithNonEffectMethod[T] derives Contravariant:
+    def foo2(a: String): String
+    def foo3(a: T): String
+
+  object AlgWithNonEffectMethodFloat extends AlgWithNonEffectMethod[Float]:
+    def foo2(a: String): String = a.reverse
+    def foo3(a: Float): String = a.toInt.toString
+
+  trait AlgWithExtraTypeParam[T1, T] derives Contravariant:
+    def foo(a: T1, b: T): Int
+
+  trait AlgWithDefaultImpl[T] derives Contravariant:
+    def plusOne(i: T): Int
+    def minusOne(i: Int): Int = i - 1
+
+  trait AlgWithGenericType[T] derives Contravariant:
+    def foo[A](i: T, a: A): Int
+
+  trait AlgWithCurry[T] derives Contravariant:
+    def foo(a: T)(b: Int): Int
+
+  trait AlgWithCurry2[T] derives Contravariant:
+    def foo(a: T)(b: Int): String
+
+  trait AlgWithVarArgsParameter[T] derives Contravariant:
+    def sum(xs: Int*): Int
+    def showAll(ts: T*): Int
+
+  object AlgWithExtraTypeParamFloat extends AlgWithExtraTypeParam[String, Float]:
+    def foo(a: String, b: Float): Int = (a.length.toFloat + b).toInt
+
+  given [T: ExhaustiveCheck]: Eq[SimpleAlg[T]] =
+    Eq.by(algebra => (algebra.foo _, algebra.bar _))
+
+  given [T: Cogen]: Arbitrary[SimpleAlg[T]] =
+    Arbitrary(
+      for
+        f <- Arbitrary.arbitrary[T => String]
+        g <- Arbitrary.arbitrary[Option[T] => String]
+      yield new SimpleAlg[T]:
+        def foo(t: T) = f(t)
+        def bar(opt: Option[T]) = g(opt)
+    )

--- a/tests/src/test/scala-3/cats/tagless/tests/autoInvariantTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoInvariantTests.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.{Eq, Invariant}
+import cats.laws.discipline.{InvariantTests, SerializableTests}
+import cats.laws.discipline.eq.*
+import cats.tagless.derived.*
+import org.scalacheck.{Arbitrary, Cogen}
+
+@experimental
+class autoInvariantTests extends CatsTaglessTestSuite:
+  import autoInvariantTests.*
+
+  checkAll("SimpleAlg[Option]", InvariantTests[SimpleAlg].invariant[Float, String, Int])
+  checkAll("Invariant[SimpleAlg]", SerializableTests.serializable(Invariant[SimpleAlg]))
+
+  test("non effect method correctly delegated"):
+    val doubleAlg = AlgWithNonEffectMethodFloat.imap(_.toDouble)(_.toFloat)
+    assertEquals(doubleAlg.foo("big"), 3d)
+    assertEquals(doubleAlg.foo2("big"), "gib")
+    assertEquals(doubleAlg.foo3(3d), "3")
+
+  test("extra type param correctly handled"):
+    val doubleAlg = AlgWithExtraTypeParamFloat.imap(_.toDouble)(_.toFloat)
+    assertEquals(doubleAlg.foo("big", 3d), 6d)
+
+  test("Alg with non effect method with default Impl"):
+    val intAlg = new AlgWithDefaultImpl[Int]:
+      def plusOne(i: Int): Int = i + 1
+
+    assertEquals(intAlg.imap(_.toString)(_.toInt).plusOne("3"), "4")
+    assertEquals(intAlg.imap(_.toString)(_.toInt).minusOne(2), 1)
+
+object autoInvariantTests:
+  import TestInstances.*
+
+  trait SimpleAlg[T] derives Invariant:
+    def foo(a: T): T
+    def headOption(ts: List[T]): Option[T]
+    def map[U](ts: List[T])(f: T => U): List[U] = ts.map(f)
+
+  trait AlgWithNonEffectMethod[T] derives Invariant:
+    def foo(a: String): T
+    def foo2(a: String): String
+    def foo3(a: T): String
+
+  object AlgWithNonEffectMethodFloat extends AlgWithNonEffectMethod[Float]:
+    def foo(a: String): Float = a.length.toFloat
+    def foo2(a: String): String = a.reverse
+    def foo3(a: Float): String = a.toInt.toString
+
+  trait AlgWithDef[T] derives Invariant:
+    def foo: T
+    def bar(t: T): T
+
+  trait AlgWithExtraTypeParam[T1, T] derives Invariant:
+    def foo(a: T1, b: T): T
+
+  trait AlgWithDefaultImpl[T] derives Invariant:
+    def plusOne(i: T): T
+    def minusOne(i: Int): Int = i - 1
+
+  trait AlgWithGenericType[T] derives Invariant:
+    def foo[A](i: T, a: A): T
+
+  trait AlgWithCurry[T] derives Invariant:
+    def foo(a: T)(b: Int): T
+
+  trait AlgWithCurry2[T] derives Invariant:
+    def foo(a: T)(b: Int): String
+
+  object AlgWithExtraTypeParamFloat extends AlgWithExtraTypeParam[String, Float]:
+    def foo(a: String, b: Float): Float = a.length.toFloat + b
+
+  given [T: Arbitrary: Cogen: Eq]: Eq[SimpleAlg[T]] =
+    Eq.by(algebra => (algebra.foo _, algebra.headOption _, algebra.map[Int] _))
+
+  given [T: Arbitrary: Cogen]: Arbitrary[SimpleAlg[T]] =
+    Arbitrary(
+      for
+        f <- Arbitrary.arbitrary[T => T]
+        hOpt <- Arbitrary.arbitrary[List[T] => Option[T]]
+      yield new SimpleAlg[T]:
+        def foo(i: T): T = f(i)
+        def headOption(list: List[T]) = hOpt(list)
+    )
+
+  trait AlgWithVarArgsParameter[T] derives Invariant:
+    def sum(xs: Int*): Int
+    def covariantSum(xs: Int*): T
+    def contravariantSum(xs: T*): Int
+    def invariantSum(xs: T*): T


### PR DESCRIPTION
This PR adds derivation for Contravariant and Invariant ~~, depends on https://github.com/typelevel/cats-tagless/pull/532~~

~~Note: https://github.com/typelevel/cats-tagless/pull/532 should be merged in first, I'll cherry-pick (it's just a single commit) / rebase it on top of main after that.~~

Linked https://github.com/typelevel/cats-tagless/issues/170