### PR TITLE
[Scala 3] Derive Semigroupal

### DIFF
--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -28,6 +28,7 @@ object Derive:
   inline def functor[F[_]]: Functor[F] = MacroFunctor.derive[F]
   inline def contravariant[F[_]]: Contravariant[F] = MacroContravariant.derive[F]
   inline def invariant[F[_]]: Invariant[F] = MacroInvariant.derive[F]
+  inline def semigroupal[F[_]]: Semigroupal[F] = MacroSemigroupal.derive[F]
   inline def bifunctor[F[_, _]]: Bifunctor[F] = MacroBifunctor.derive[F]
   inline def profunctor[F[_, _]]: Profunctor[F] = MacroProfunctor.derive[F]
   inline def functorK[Alg[_[_]]]: FunctorK[Alg] = MacroFunctorK.derive[Alg]

--- a/core/src/main/scala-3/cats/tagless/derived/package.scala
+++ b/core/src/main/scala-3/cats/tagless/derived/package.scala
@@ -25,5 +25,6 @@ import scala.annotation.experimental
 extension (x: Functor.type) @experimental inline def derived[F[_]]: Functor[F] = Derive.functor
 extension (x: Contravariant.type) @experimental inline def derived[F[_]]: Contravariant[F] = Derive.contravariant
 extension (x: Invariant.type) @experimental inline def derived[F[_]]: Invariant[F] = Derive.invariant
+extension (x: Semigroupal.type) @experimental inline def derived[F[_]]: Semigroupal[F] = Derive.semigroupal
 extension (x: Bifunctor.type) @experimental inline def derived[F[_, _]]: Bifunctor[F] = Derive.bifunctor
 extension (x: Profunctor.type) @experimental inline def derived[F[_, _]]: Profunctor[F] = Derive.profunctor

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -160,6 +160,9 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
     def contains(sym: Symbol): Boolean =
       tpe != tpe.substituteTypes(sym :: Nil, TypeRepr.of[Any] :: Nil)
 
+    def containsAll(syms: Symbol*): Boolean =
+      syms.forall(tpe.contains)
+
     def isRepeated: Boolean =
       tpe.typeSymbol == defn.RepeatedParamClass
 

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -37,31 +37,45 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
     List(Flags.Final, Flags.Artifact, Flags.Synthetic, Flags.Mutable, Flags.Param)
 
   extension (xf: Transform)
-    def transformRepeated(method: Symbol, tpe: TypeRepr, arg: Term): Tree =
+    def transformRepeated(tpe: TypeRepr, arg: Term): Tree =
       val x = Symbol.freshName("x")
       val resultType = xf(tpe, Select.unique(arg, "head")).tpe
       val lambdaType = MethodType(x :: Nil)(_ => tpe :: Nil, _ => resultType)
-      val lambda = Lambda(method, lambdaType, (_, xs) => xf(tpe, xs.head.asExpr.asTerm))
+      val lambda = Lambda(Symbol.spliceOwner, lambdaType, (_, xs) => xf(tpe, xs.head.asExpr.asTerm))
       val result = Select.overloaded(arg, "map", resultType :: Nil, lambda :: Nil)
       val repeatedType = defn.RepeatedParamClass.typeRef.appliedTo(resultType)
       Typed(result, TypeTree.of(using repeatedType.asType))
 
-    def transformArg(method: Symbol, paramAndArg: (Definition, Tree)): Tree =
+    def transformArg(paramAndArg: (Definition, Tree)): Tree =
       paramAndArg match
         case (param: ValDef, arg: Term) =>
           val paramType = param.tpt.tpe.widenParam
           if !xf.isDefinedAt(paramType, arg) then arg
           else if !param.tpt.tpe.isRepeated then xf(paramType, arg)
-          else xf.transformRepeated(method, paramType, arg)
+          else xf.transformRepeated(paramType, arg)
         case (_, arg) => arg
 
   extension (term: Term)
-    def call(method: Symbol)(argss: List[List[Tree]]): Term =
-      argss.foldLeft[Term](term.select(method)): (term, args) =>
+    def appliedToAll(argss: List[List[Tree]]): Term =
+      argss.foldLeft(term): (term, args) =>
         val typeArgs = for case arg: TypeTree <- args yield arg
         val termArgs = for case arg: Term <- args yield arg
         if typeArgs.isEmpty then term.appliedToArgs(termArgs)
         else term.appliedToTypeTrees(typeArgs)
+
+    def call(method: Symbol)(argss: List[List[Tree]]): Term = argss match
+      case args1 :: args2 :: argss if !args1.exists(_.isExpr) && args2.forall(_.isExpr) =>
+        val typeArgs = for case arg: TypeTree <- args1 yield arg.tpe
+        val termArgs = for case arg: Term <- args2 yield arg
+        Select.overloaded(term, method.name, typeArgs, termArgs).appliedToAll(argss)
+      case args :: argss if !args.exists(_.isExpr) =>
+        val typeArgs = for case arg: TypeTree <- args yield arg.tpe
+        Select.overloaded(term, method.name, typeArgs, Nil).appliedToAll(argss)
+      case args :: argss if args.forall(_.isExpr) =>
+        val termArgs = for case arg: Term <- args yield arg
+        Select.overloaded(term, method.name, Nil, termArgs).appliedToAll(argss)
+      case argss =>
+        term.select(method).appliedToAll(argss)
 
     def transformTo[A: Type](
         args: Transform = PartialFunction.empty,
@@ -75,7 +89,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         val delegate = term.call(method.symbol):
           for (params, xs) <- method.paramss.zip(argss)
           yield for paramAndArg <- params.params.zip(xs)
-          yield args.transformArg(method.symbol, paramAndArg)
+          yield args.transformArg(paramAndArg).changeOwner(method.symbol)
         Some(body.applyOrElse((method.returnTpt.tpe, delegate), _ => delegate))
 
       def transformVal(value: ValDef): Option[Term] =
@@ -94,9 +108,6 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
       Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[A]
 
   extension (terms: Seq[Term])
-    def call(method: Symbol)(argss: List[List[Tree]]): Seq[Term] =
-      terms.map(_.call(method)(argss))
-
     def combineTo[A: Type](
         args: Seq[Transform] = Nil,
         body: Combine = PartialFunction.empty
@@ -112,7 +123,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
             term.call(method.symbol):
               for (params, args) <- method.paramss.zip(argss)
               yield for paramAndArg <- params.params.zip(args)
-              yield xf.transformArg(method.symbol, paramAndArg)
+              yield xf.transformArg(paramAndArg).changeOwner(method.symbol)
         Some(body.applyOrElse((method.returnTpt.tpe, delegates), _ => delegates.head))
 
       def combineVal(value: ValDef): Option[Term] =

--- a/core/src/main/scala-3/cats/tagless/macros/MacroBifunctor.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroBifunctor.scala
@@ -49,7 +49,7 @@ object MacroBifunctor:
 
     fab.asTerm.transformTo[F[C, D]](
       args = {
-        case (tpe, arg) if tpe.contains(c) && tpe.contains(d) =>
+        case (tpe, arg) if tpe.containsAll(c, d) =>
           report.errorAndAbort(s"Both type parameters ${A.show} and ${B.show} appear in contravariant position")
         case (tpe, arg) if tpe.contains(c) =>
           Select
@@ -65,7 +65,7 @@ object MacroBifunctor:
             .appliedTo(g.asTerm)
       },
       body = {
-        case (tpe, body) if tpe.contains(c) && tpe.contains(d) =>
+        case (tpe, body) if tpe.containsAll(c, d) =>
           Select
             .unique(tpe.summonLambda[Bifunctor](c, d), "bimap")
             .appliedToTypes(List(A, B, C, D))

--- a/core/src/main/scala-3/cats/tagless/macros/MacroProfunctor.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroProfunctor.scala
@@ -50,7 +50,7 @@ object MacroProfunctor:
 
     fab.asTerm.transformTo[F[C, D]](
       args = {
-        case (tpe, arg) if tpe.contains(c) && tpe.contains(d) =>
+        case (tpe, arg) if tpe.containsAll(c, d) =>
           Select
             .unique(tpe.summonLambda[Profunctor](d, c), "dimap")
             .appliedToTypes(List(D, C, B, A))
@@ -71,7 +71,7 @@ object MacroProfunctor:
             .appliedTo(g.asTerm)
       },
       body = {
-        case (tpe, body) if tpe.contains(c) && tpe.contains(d) =>
+        case (tpe, body) if tpe.containsAll(c, d) =>
           Select
             .unique(tpe.summonLambda[Profunctor](c, d), "dimap")
             .appliedToTypes(List(A, B, C, D))

--- a/core/src/main/scala-3/cats/tagless/macros/MacroSemigroupal.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroSemigroupal.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.{Functor, Semigroup, Semigroupal}
+import cats.tagless.*
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroSemigroupal:
+  inline def derive[F[_]] = ${ semigroupal[F] }
+
+  def semigroupal[F[_]: Type](using Quotes): Expr[Semigroupal[F]] = '{
+    new Semigroupal[F]:
+      def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] =
+        ${ deriveProduct('{ fa }, '{ fb }) }
+  }
+
+  private[macros] def deriveProduct[F[_]: Type, A: Type, B: Type](
+      fa: Expr[F[A]],
+      fb: Expr[F[B]]
+  )(using q: Quotes): Expr[F[(A, B)]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val A = TypeRepr.of[A]
+    val B = TypeRepr.of[B]
+    val T = TypeRepr.of[(A, B)]
+    val a = A.typeSymbol
+    val b = B.typeSymbol
+    val t = T.typeSymbol
+
+    type First[X, Y] = X
+    extension (tpe: TypeRepr)
+      def first: TypeRepr =
+        tpe.substituteTypes(t :: Nil, TypeRepr.of[First] :: Nil)
+
+    def tuple(name: String, result: TypeRepr): Term =
+      val tpe = MethodType("t" :: Nil)(_ => T :: Nil, _ => result)
+      Lambda(Symbol.spliceOwner, tpe, (_, args) => Select.unique(args.head.asExpr.asTerm, name))
+
+    List(fa.asTerm, fb.asTerm).combineTo[F[(A, B)]](
+      args = List(
+        {
+          case (tpe, arg) if tpe.containsAll(t, a, b) =>
+            Select
+              .unique(tpe.first.summonLambda[Functor](a), "map")
+              .appliedToTypes(List(T, A))
+              .appliedTo(arg)
+              .appliedTo(tuple("_1", A))
+        },
+        {
+          case (tpe, arg) if tpe.containsAll(t, a, b) =>
+            Select
+              .unique(tpe.first.summonLambda[Functor](a), "map")
+              .appliedToTypes(List(T, B))
+              .appliedTo(arg)
+              .appliedTo(tuple("_2", B))
+        }
+      ),
+      body = {
+        case (tpe, af :: ag :: Nil) if tpe.containsAll(t, a, b) =>
+          Select
+            .unique(tpe.first.summonLambda[Semigroupal](a), "product")
+            .appliedToTypes(List(A, B))
+            .appliedTo(af, ag)
+        case (tpe, af :: ag :: Nil) =>
+          Implicits.search(TypeRepr.of[Semigroup].appliedTo(tpe)) match
+            case success: ImplicitSearchSuccess => Select.unique(success.tree, "combine").appliedTo(af, ag)
+            case _ => af
+      }
+    )

--- a/core/src/main/scala-3/cats/tagless/macros/MacroSemigroupalK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroSemigroupalK.scala
@@ -44,6 +44,7 @@ object MacroSemigroupalK:
     val G = TypeRepr.of[G]
     val T2K = TypeRepr.of[Tuple2K[F, G, *]]
     val f = F.typeSymbol
+    val g = G.typeSymbol
     val t2k = T2K.typeSymbol
 
     type FirstK[H[_], I[_], A] = H[A]
@@ -57,7 +58,7 @@ object MacroSemigroupalK:
     List(eaf.asTerm, eag.asTerm).combineTo[Alg[Tuple2K[F, G, *]]](
       args = List(
         {
-          case (tpe, arg) if tpe.contains(t2k) =>
+          case (tpe, arg) if tpe.containsAll(t2k, f, g) =>
             Select
               .unique(tpe.firstK.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(T2K, F))
@@ -65,7 +66,7 @@ object MacroSemigroupalK:
               .appliedTo(tuple2K("firstK"))
         },
         {
-          case (tpe, arg) if tpe.contains(t2k) =>
+          case (tpe, arg) if tpe.containsAll(t2k, f, g) =>
             Select
               .unique(tpe.firstK.summonLambda[FunctorK](f), "mapK")
               .appliedToTypes(List(T2K, G))
@@ -74,7 +75,7 @@ object MacroSemigroupalK:
         }
       ),
       body = {
-        case (tpe, af :: ag :: Nil) if tpe.contains(t2k) =>
+        case (tpe, af :: ag :: Nil) if tpe.containsAll(t2k, f, g) =>
           Select
             .unique(tpe.firstK.summonLambda[SemigroupalK](f), "productK")
             .appliedToTypes(List(F, G))

--- a/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/autoSemigroupalTests.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.tests
+
+import cats.laws.discipline.eq.*
+import cats.laws.discipline.{SemigroupalTests, SerializableTests}
+import cats.tagless.derived.*
+import cats.{Eq, Invariant, Semigroupal}
+import org.scalacheck.{Arbitrary, Cogen}
+
+@experimental
+class autoSemigroupalTests extends CatsTaglessTestSuite:
+  import autoSemigroupalTests.*
+
+  checkAll("Semigroupal[TestAlgebra]", SemigroupalTests[TestAlgebra].semigroupal[Long, String, Int])
+  checkAll("Serializable Semigroupal[TestAlgebra]", SerializableTests.serializable(Semigroupal[TestAlgebra]))
+
+object autoSemigroupalTests:
+  import TestInstances.*
+
+  // Invariant needed for Isomorphisms
+  trait TestAlgebra[T] derives Invariant, Semigroupal:
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def curried(a: String)(b: Int): T
+    def headOption(ts: List[T]): Option[T]
+
+  trait AlgWithExtraTypeParam[T1, T] derives Semigroupal:
+    def foo(a: T1): T
+
+  trait AlgWithGenericMethod[T] derives Semigroupal:
+    def plusOne[A](i: A): T
+
+  trait AlgWithVarArgsParameter[T] derives Semigroupal:
+    def sum(xs: Int*): Int
+    def product(xs: Int*): T
+
+  trait AlgWithConstantReturnTypes[T] derives Semigroupal:
+    def fromInt(i: Int): T
+    def toString(t: T): String
+    def toError(t: T): Exception
+
+  given [T: Arbitrary: Eq]: Eq[TestAlgebra[T]] =
+    Eq.by: algebra =>
+      (
+        algebra.abstractEffect,
+        algebra.concreteEffect,
+        algebra.abstractOther,
+        algebra.concreteOther,
+        algebra.withoutParams,
+        Function.uncurried(algebra.curried).tupled,
+        algebra.headOption
+      )
+
+  given [T: Arbitrary: Cogen]: Arbitrary[TestAlgebra[T]] =
+    Arbitrary(for
+      absEff <- Arbitrary.arbitrary[String => T]
+      conEff <- Arbitrary.arbitrary[Option[String => T]]
+      absOther <- Arbitrary.arbitrary[String => String]
+      conOther <- Arbitrary.arbitrary[Option[String => String]]
+      withoutParameters <- Arbitrary.arbitrary[T]
+      curry <- Arbitrary.arbitrary[String => Int => T]
+      hOpt <- Arbitrary.arbitrary[List[T] => Option[T]]
+    yield new TestAlgebra[T]:
+      override def abstractEffect(i: String) = absEff(i)
+      override def concreteEffect(a: String) = conEff.getOrElse(super.concreteEffect)(a)
+      override def abstractOther(a: String) = absOther(a)
+      override def concreteOther(a: String) = conOther.getOrElse(super.concreteOther)(a)
+      override def withoutParams = withoutParameters
+      override def curried(a: String)(b: Int) = curry(a)(b)
+      override def headOption(ts: List[T]): Option[T] = hOpt(ts)
+    )


### PR DESCRIPTION
 - Handle overloaded methods correctly
 - Change owner when transforming args, so we can use lambdas
 - Match tuple types more precisely for `SemigroupalK` and `Semigroupal`