### PR TITLE
Auto derive Scala 3 macro for ReaderT

### DIFF
--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -17,6 +17,7 @@
 package cats.tagless
 
 import cats.*
+import cats.data.ReaderT
 import cats.arrow.Profunctor
 import cats.tagless.*
 import cats.tagless.aop.*
@@ -41,4 +42,9 @@ object Derive:
   inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive
   inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive
   inline def applyK[Alg[_[_]]]: ApplyK[Alg] = MacroApplyK.derive
+
+  /** Derives an implementation of `Alg` that forwards all calls to another one supplied via `ReaderT`. This enables a
+    * form of dependency injection.
+    */
+  inline def readerT[Alg[_[_]], F[_]]: Alg[[X] =>> ReaderT[F, Alg[F], X]] = MacroReaderT.derive
   inline def instrument[Alg[_[_]]]: Instrument[Alg] = MacroInstrument.derive

--- a/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
@@ -47,8 +47,7 @@ object MacroReaderT:
         owner,
         methodType,
         {
-          case (sym, (af: Term) :: Nil) =>
-            body(af).changeOwner(sym)
+          case (sym, (af: Term) :: Nil) => body(af)
           case (_, List(tree)) => tree
           case (sym, args) =>
             report.errorAndAbort(s"Unexpected: $sym with args ${args.map(_.show)}")

--- a/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.tagless.*
+import cats.data.ReaderT
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroReaderT:
+
+  inline def derive[Alg[_[_]], F[_]]: Alg[[X] =>> ReaderT[F, Alg[F], X]] = ${ deriveReaderT }
+
+  private[macros] def deriveReaderT[Alg[_[_]]: Type, F[_]: Type](using
+      q: Quotes
+  ): Expr[Alg[[X] =>> ReaderT[F, Alg[F], X]]] =
+    import quotes.reflect.*
+    given dm: DeriveMacros[q.type] = new DeriveMacros
+
+    val F = TypeRepr.of[F]
+    val ReaderT = TypeRepr.of[ReaderT]
+    val AlgF = TypeRepr.of[Alg[F]]
+
+    val name = Symbol.freshName("$anon")
+    val parents = List(TypeTree.of[Object], TypeTree.of[Alg[[X] =>> ReaderT[F, Alg[F], X]]])
+    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
+
+    def readerT(owner: Symbol, resultTpe: TypeRepr)(body: Term => Term): Term =
+      val methodType = MethodType(List("af"))(_ => List(AlgF), _ => F.appliedTo(resultTpe))
+      val lambda = Lambda(
+        owner,
+        methodType,
+        {
+          case (sym, (af: Term) :: Nil) =>
+            body(af).changeOwner(sym)
+          case (_, List(tree)) => tree
+          case (sym, args) =>
+            report.errorAndAbort(s"Unexpected: $sym with args ${args.map(_.show)}")
+        }
+      )
+      Select
+        .unique(Ident(ReaderT.typeSymbol.companionModule.termRef), "apply")
+        .appliedToTypes(F :: AlgF :: resultTpe :: Nil)
+        .appliedTo(lambda)
+
+    def argTransformer(af: Term): dm.Transform = {
+      case (_, tpe, arg) if tpe <:< TypeRepr.of[ReaderT[F, Alg[F], ?]] =>
+        val newArg = tpe.typeArgs.last.asType match
+          case '[t] =>
+            '{ ${ arg.asExprOf[ReaderT[F, Alg[F], t]] }.run(${ af.asExprOf[Alg[F]] }) }
+        newArg.asTerm
+    }
+
+    def transformDef(method: DefDef)(argss: List[List[Tree]]): Option[Term] =
+      val methodReturnTpe = method.returnTpt.tpe.typeArgs.drop(2).head
+
+      Some(readerT(method.symbol, methodReturnTpe) { af =>
+        val transformedArgss =
+          for (clause, xs) <- method.paramss.zip(argss)
+          yield for paramAndArg <- clause.params.zip(xs)
+          yield argTransformer(af).transformArg(method.symbol, paramAndArg)
+
+        af.call(method.symbol)(transformedArgss)
+      })
+
+    def transformVal(value: ValDef): Option[Term] =
+      val valType = value.tpt.tpe.typeArgs.drop(2).head
+      Some(readerT(value.symbol, valType) { af =>
+        af.select(value.symbol)
+      })
+
+    val members = cls.declarations.filterNot(_.isClassConstructor).map { member =>
+      member.tree match
+        case method: DefDef => DefDef(member, transformDef(method))
+        case value: ValDef => ValDef(member, transformVal(value))
+        case _ => report.errorAndAbort(s"Not supported: $member in ${member.owner}")
+    }
+
+    val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
+    Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[Alg[[X] =>> ReaderT[F, Alg[F], X]]]

--- a/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
@@ -20,11 +20,9 @@ package tests
 import cats.arrow.FunctionK
 import cats.data.ReaderT
 import cats.FlatMap
-import cats.tagless.derived.*
 
 import scala.util.{Failure, Success, Try}
 import scala.annotation.experimental
-import cats.data.Reader
 
 @experimental
 class ReaderTTests extends CatsTaglessTestSuite:

--- a/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless
+package tests
+
+import cats.arrow.FunctionK
+import cats.data.ReaderT
+import cats.FlatMap
+import cats.tagless.derived.*
+
+import scala.util.{Failure, Success, Try}
+import scala.annotation.experimental
+import cats.data.Reader
+
+@experimental
+class ReaderTTests extends CatsTaglessTestSuite:
+  import ReaderTTests.*
+
+  type F[A] = ReaderT[Try, SpaceAlg[Try], A]
+  type SyncIO[A] = () => Try[A] // poor man's SyncIO
+
+  val dependency: SpaceAlg[Try] = new SpaceAlg[Try]:
+    def blackHole[A](anything: Try[A]) = anything.void
+    def distance(x: Galaxy, y: Galaxy) = Success((x.name.sum + y.name.sum) / 2.0)
+    def collision(x: Try[Galaxy], y: Try[Galaxy]) = for
+      x <- x.map(_.name)
+      y <- y.map(_.name)
+    yield Galaxy(x.zip(y).map { case (x, y) => s"$x$y" }.mkString(""))
+
+  test("Dependency injection") {
+    assertEquals(spaceAlg.blackHole(ReaderT(_ => eventHorizon)).run(dependency), eventHorizon)
+    assertEquals(spaceAlg.distance(milkyWay, andromeda).run(dependency), Success(881.0))
+    assertEquals(
+      spaceAlg.collision(milkyWay.pure[F], andromeda.pure[F]).run(dependency),
+      Success(Galaxy("MAinldkryo mWeadya"))
+    )
+  }
+
+  // The same approach could be used for Future ~> IO
+  test("Try ~> SyncIO") {
+    def provide[R](service: R) = FunctionKLift[[X] =>> ReaderT[Try, R, X], SyncIO](r => () => r(service))
+    def require[R] = FunctionKLift[SyncIO, [X] =>> ReaderT[Try, R, X]](io => ReaderT(_ => io()))
+
+    var successful, failed = 0
+    // Make the dependency side-effecting
+    val sideEffecting = dependency.imapK(FunctionKLift[Try, Try] {
+      case success @ Success(_) => successful += 1; success
+      case failure @ Failure(_) => failed += 1; failure
+    })(FunctionK.id)
+
+    val alg = spaceAlg.imapK(provide(sideEffecting))(require)
+    val blackHole = alg.blackHole(() => eventHorizon)
+    val distance = alg.distance(milkyWay, andromeda)
+    val collision = alg.collision(() => Success(milkyWay), () => Success(andromeda))
+
+    assertEquals(failed, 0)
+    assertEquals(blackHole(), eventHorizon)
+    assertEquals(failed, 1)
+    assertEquals(successful, 0)
+    assertEquals(distance(), Success(881.0))
+    assertEquals(successful, 1)
+    assertEquals(collision(), Success(Galaxy("MAinldkryo mWeadya")))
+    assertEquals(successful, 2)
+  }
+
+  // The same approach could be used for accessing a service in a Ref
+  test("Try ~> Try") {
+    def provide[G[_]: FlatMap, A](service: G[A]) =
+      FunctionKLift[([X] =>> ReaderT[G, A, X]), G](r => service.flatMap(r.run))
+
+    val alg = spaceAlg.imapK(provide(Success(dependency)))(ReaderT.liftK)
+    assertEquals(alg.blackHole(eventHorizon), eventHorizon)
+    assertEquals(alg.distance(milkyWay, andromeda), Success(881.0))
+    assertEquals(alg.collision(Success(milkyWay), Success(andromeda)), Success(Galaxy("MAinldkryo mWeadya")))
+
+    val failingAlg = spaceAlg.imapK(provide(eventHorizon))(ReaderT.liftK)
+    assertEquals(failingAlg.blackHole(eventHorizon), eventHorizon)
+    assertEquals(failingAlg.distance(milkyWay, andromeda), eventHorizon)
+    assertEquals(failingAlg.collision(Success(milkyWay), Success(andromeda)), eventHorizon)
+  }
+
+@experimental
+object ReaderTTests:
+  final case class Galaxy(name: String)
+  final case class Error(message: String) extends RuntimeException(message)
+
+  val spaceAlg = Derive.readerT[SpaceAlg, Try]
+  implicit val invariantK: InvariantK[SpaceAlg] = Derive.invariantK
+
+  val milkyWay = Galaxy("Milky Way")
+  val andromeda = Galaxy("Andromeda")
+  val eventHorizon = Failure(Error("past event horizon"))
+
+  trait SpaceAlg[F[_]]:
+    def blackHole[A](anything: F[A]): F[Unit]
+    def distance(x: Galaxy, y: Galaxy): F[Double]
+    def collision(x: F[Galaxy], y: F[Galaxy]): F[Galaxy]
+  

--- a/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
@@ -107,4 +107,3 @@ object ReaderTTests:
     def blackHole[A](anything: F[A]): F[Unit]
     def distance(x: Galaxy, y: Galaxy): F[Double]
     def collision(x: F[Galaxy], y: F[Galaxy]): F[Galaxy]
-  


### PR DESCRIPTION
Initial implementation of a macro for auto-derivation of algebras based on `ReaderT`, which results useful to transform side-effecting algebra implementations into algebras using cats-effect `IO`.

The implementation holds some duplication in relation to the common code found in `DeriveMacros` utility extensions. It's been left in the macro implementation because, even though there are some commonalities, the derivation of `ReaderT` has its own peculiarities that may not be worth a refactor on the common utilities. Up to discussion, obviously.