### PR TITLE
[Scala 3] Add derivation for Const and Void

### DIFF
--- a/core/src/main/scala-3/cats/tagless/Derive.scala
+++ b/core/src/main/scala-3/cats/tagless/Derive.scala
@@ -42,6 +42,8 @@ object Derive:
   inline def invariantK[Alg[_[_]]]: InvariantK[Alg] = MacroInvariantK.derive
   inline def semigroupalK[Alg[_[_]]]: SemigroupalK[Alg] = MacroSemigroupalK.derive
   inline def applyK[Alg[_[_]]]: ApplyK[Alg] = MacroApplyK.derive
+  inline def const[Alg[_[_]], A](value: A): Alg[Const[A]#λ] = MacroConst.derive[Alg, A](value)
+  inline def void[Alg[_[_]]]: Alg[Const[Unit]#λ] = MacroConst.derive[Alg, Unit](())
 
   /** Derives an implementation of `Alg` that forwards all calls to another one supplied via `ReaderT`. This enables a
     * form of dependency injection.

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -104,7 +104,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         val delegate = term.select(sym)
         Some(body.applyOrElse((sym, value.tpt.tpe, delegate), _ => delegate))
 
-      newClassOf[A](transformDef, transformVal)
+      Symbol.newClassOf[A](transformDef, transformVal)
 
   extension (exprs: Seq[Expr[?]])
     def combineTo[A: Type](
@@ -129,7 +129,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         val delegates = terms.map(_.select(sym))
         Some(body.applyOrElse((sym, value.tpt.tpe, delegates), _ => delegates.head))
 
-      newClassOf[A](combineDef, combineVal)
+      Symbol.newClassOf[A](combineDef, combineVal)
 
   extension (sym: Symbol)
     def privateIn: Symbol =
@@ -198,23 +198,24 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         case success: ImplicitSearchSuccess => Some(success.tree)
         case _ => None
 
-  def newClassOf[T: Type](
-      transformDef: DefDef => List[List[Tree]] => Option[Term],
-      transformVal: ValDef => Option[Term]
-  ): Expr[T] =
-    val name = Symbol.freshName("$anon")
-    val parents = List(TypeTree.of[Object], TypeTree.of[T])
-    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
+  extension (symbol: SymbolModule)
+    def newClassOf[T: Type](
+        transformDef: DefDef => List[List[Tree]] => Option[Term],
+        transformVal: ValDef => Option[Term]
+    ): Expr[T] =
+      val name = symbol.freshName("$anon")
+      val parents = List(TypeTree.of[Object], TypeTree.of[T])
+      val cls = symbol.newClass(symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
 
-    val members = cls.declarations
-      .filterNot(_.isClassConstructor)
-      .map: member =>
-        member.tree match
-          case method: DefDef => DefDef(member, transformDef(method))
-          case value: ValDef => ValDef(member, transformVal(value))
-          case _ => report.errorAndAbort(s"Not supported: $member in ${member.owner}")
+      val members = cls.declarations
+        .filterNot(_.isClassConstructor)
+        .map: member =>
+          member.tree match
+            case method: DefDef => DefDef(member, transformDef(method))
+            case value: ValDef => ValDef(member, transformVal(value))
+            case _ => report.errorAndAbort(s"Not supported: $member in ${member.owner}")
 
-    val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
-    Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[T]
+      val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
+      Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[T]
 
 end DeriveMacros

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -222,4 +222,23 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         case success: ImplicitSearchSuccess => Some(success.tree)
         case _ => None
 
+  def newClassOf[T: Type](
+      transformDef: DefDef => List[List[Tree]] => Option[Term],
+      transformVal: ValDef => Option[Term]
+  ): Expr[T] =
+    val name = Symbol.freshName("$anon")
+    val parents = List(TypeTree.of[Object], TypeTree.of[T])
+    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
+
+    val members = cls.declarations
+      .filterNot(_.isClassConstructor)
+      .map: member =>
+        member.tree match
+          case method: DefDef => DefDef(member, transformDef(method))
+          case value: ValDef => ValDef(member, transformVal(value))
+          case _ => report.errorAndAbort(s"Not supported: $member in ${member.owner}")
+
+    val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
+    Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[T]
+
 end DeriveMacros

--- a/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/DeriveMacros.scala
@@ -90,9 +90,6 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         body: Transform = PartialFunction.empty
     ): Expr[A] =
       val term = expr.asTerm
-      val name = Symbol.freshName("$anon")
-      val parents = List(TypeTree.of[Object], TypeTree.of[A])
-      val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
 
       def transformDef(method: DefDef)(argss: List[List[Tree]]): Option[Term] =
         val sym = method.symbol
@@ -107,16 +104,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         val delegate = term.select(sym)
         Some(body.applyOrElse((sym, value.tpt.tpe, delegate), _ => delegate))
 
-      val members = cls.declarations
-        .filterNot(_.isClassConstructor)
-        .map: sym =>
-          sym.tree match
-            case method: DefDef => DefDef(sym, transformDef(method))
-            case value: ValDef => ValDef(sym, transformVal(value))
-            case _ => report.errorAndAbort(s"Not supported: $sym in ${sym.owner}")
-
-      val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
-      Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[A]
+      newClassOf[A](transformDef, transformVal)
 
   extension (exprs: Seq[Expr[?]])
     def combineTo[A: Type](
@@ -124,9 +112,6 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         body: Combine = PartialFunction.empty
     ): Expr[A] =
       val terms = exprs.map(_.asTerm)
-      val name = Symbol.freshName("$anon")
-      val parents = List(TypeTree.of[Object], TypeTree.of[A])
-      val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
 
       def combineDef(method: DefDef)(argss: List[List[Tree]]): Option[Term] =
         val sym = method.symbol
@@ -144,16 +129,7 @@ private class DeriveMacros[Q <: Quotes](using val q: Q):
         val delegates = terms.map(_.select(sym))
         Some(body.applyOrElse((sym, value.tpt.tpe, delegates), _ => delegates.head))
 
-      val members = cls.declarations
-        .filterNot(_.isClassConstructor)
-        .map: sym =>
-          sym.tree match
-            case method: DefDef => DefDef(sym, combineDef(method))
-            case value: ValDef => ValDef(sym, combineVal(value))
-            case _ => report.errorAndAbort(s"Not supported: $sym in ${sym.owner}")
-
-      val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
-      Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[A]
+      newClassOf[A](combineDef, combineVal)
 
   extension (sym: Symbol)
     def privateIn: Symbol =

--- a/core/src/main/scala-3/cats/tagless/macros/MacroConst.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroConst.scala
@@ -27,9 +27,9 @@ object MacroConst:
 
   private[macros] def deriveConst[Alg[_[_]]: Type, A: Type](const: Expr[A])(using q: Quotes): Expr[Alg[Const[A]#λ]] =
     import quotes.reflect.*
-    given dm: DeriveMacros[q.type] = new DeriveMacros
+    given DeriveMacros[q.type] = new DeriveMacros
 
-    dm.newClassOf[Alg[Const[A]#λ]](
+    Symbol.newClassOf[Alg[Const[A]#λ]](
       transformDef = _ => _ => Some(const.asTerm),
       transformVal = _ => Some(const.asTerm)
     )

--- a/core/src/main/scala-3/cats/tagless/macros/MacroConst.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroConst.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 cats-tagless maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.tagless.macros
+
+import cats.tagless.*
+
+import scala.annotation.experimental
+import scala.quoted.*
+
+@experimental
+object MacroConst:
+  inline def derive[Alg[_[_]], A](const: A): Alg[Const[A]#λ] = ${ deriveConst[Alg, A]('const) }
+
+  private[macros] def deriveConst[Alg[_[_]]: Type, A: Type](const: Expr[A])(using q: Quotes): Expr[Alg[Const[A]#λ]] =
+    import quotes.reflect.*
+    given DeriveMacros[q.type] = new DeriveMacros
+
+    val name = Symbol.freshName("$anon")
+    val parents = List(TypeTree.of[Object], TypeTree.of[Alg[Const[A]#λ]])
+    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _.overridableMembers, None)
+
+    val members = cls.declarations
+      .filterNot(_.isClassConstructor)
+      .map: member =>
+        member.tree match
+          case method: DefDef => DefDef(member, _ => Some(const.asTerm))
+          case value: ValDef => ValDef(member, Some(const.asTerm))
+          case _ => report.errorAndAbort(s"Not supported: $member in ${member.owner}")
+
+    val newCls = New(TypeIdent(cls)).select(cls.primaryConstructor).appliedToNone
+    Block(ClassDef(cls, parents, members) :: Nil, newCls).asExprOf[Alg[Const[A]#λ]]

--- a/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
@@ -60,4 +60,4 @@ object MacroReaderT:
         case _ =>
           value.rhs
 
-    dm.newClassOf[Alg[[X] =>> ReaderT[F, Alg[F], X]]](transformDef, transformVal)
+    Symbol.newClassOf[Alg[[X] =>> ReaderT[F, Alg[F], X]]](transformDef, transformVal)

--- a/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
@@ -18,6 +18,7 @@ package cats.tagless.tests
 
 import cats.tagless.Derive
 
+@experimental
 class ConstTests extends CatsTaglessTestSuite {
 
   test("const(42)") {


### PR DESCRIPTION
This PR adds a `ConstMacro` and both `Derive.const` / `Derive.void` functions. 
I also added an extra helper function, apparently it's used a lot!

Connected https://github.com/typelevel/cats-tagless/issues/170