### PR TITLE
[Scala 3] MacroConst and MacroReaderT Errors readability improvement

### DIFF
--- a/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroReaderT.scala
@@ -51,13 +51,17 @@ object MacroReaderT:
               yield argTransformer(af).transformArg(method.symbol, paramAndArg)
           )
         case _ =>
-          method.rhs
+          report.errorAndAbort(
+            s"Expected method ${method.name} to return ${RT.show} but found ${method.returnTpt.tpe.show}"
+          )
 
     def transformVal(value: ValDef): Option[Term] =
       value.tpt.tpe.asType match
         case '[ReaderT[F, Alg[F], t]] =>
           Some(readerT[t](value.symbol)(_.select(value.symbol)))
         case _ =>
-          value.rhs
+          report.errorAndAbort(
+            s"Expected value ${value.name} to be of type ${RT.show} but found ${value.tpt.tpe.show}"
+          )
 
     Symbol.newClassOf[Alg[[X] =>> ReaderT[F, Alg[F], X]]](transformDef, transformVal)

--- a/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
+++ b/tests/src/test/scala-3/cats/tagless/tests/ReaderTTests.scala
@@ -88,6 +88,13 @@ class ReaderTTests extends CatsTaglessTestSuite:
     assertEquals(failingAlg.distance(milkyWay, andromeda), eventHorizon)
     assertEquals(failingAlg.collision(Success(milkyWay), Success(andromeda)), eventHorizon)
 
+  test("readable macro error"):
+    assert(
+      compileErrors("Derive.readerT[BrokenSpaceAlg, Try]").contains(
+        "Expected method deathStar to return cats.data.Kleisli"
+      )
+    )
+
 @experimental
 object ReaderTTests:
   final case class Galaxy(name: String)
@@ -102,3 +109,6 @@ object ReaderTTests:
     def blackHole[A](anything: F[A]): F[Unit]
     def distance(x: Galaxy, y: Galaxy): F[Double]
     def collision(x: F[Galaxy], y: F[Galaxy]): F[Galaxy]
+
+  trait BrokenSpaceAlg[F[_]] extends SpaceAlg[F]:
+    def deathStar: String

--- a/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
@@ -41,10 +41,10 @@ class ConstTests extends CatsTaglessTestSuite {
   }
 
   test("readable macro error") {
-    assert(compileErrors("Derive.const[NotSimpleAlg, Int](42)").contains("Expected method str to return"))
+    assert(compileErrors("Derive.const[UnSafeAlg, Int](42)").contains("Expected method str to return"))
   }
 
-  trait NotSimpleAlg[F[_]] extends SafeAlg[F] {
+  trait UnSafeAlg[F[_]] extends SafeAlg[F] {
     def str(s: String): String
   }
 }

--- a/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tagless/tests/ConstTests.scala
@@ -39,4 +39,12 @@ class ConstTests extends CatsTaglessTestSuite {
     assertEquals(safe.divide(1, 2), 1)
     assertEquals(safe.parseInt("NaN"), 1)
   }
+
+  test("readable macro error") {
+    assert(compileErrors("Derive.const[NotSimpleAlg, Int](42)").contains("Expected method str to return"))
+  }
+
+  trait NotSimpleAlg[F[_]] extends SafeAlg[F] {
+    def str(s: String): String
+  }
 }


### PR DESCRIPTION
I still took a closer look into the comment left here https://github.com/typelevel/cats-tagless/pull/560#discussion_r1675658431 

It is true that macro generated code fails to compile & errors produced are OK but a bit cryptic:

```scala
[error] 31 |    val safe = Derive.const[NotSimpleAlg, Int](42)
[error]    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |Malformed tree was found while expanding macro with -Xcheck-macros.
[error]    |               |The tree does not conform to the compiler's tree invariants.
[error]    |               |
[error]    |               |Macro was:
[error]    |               |scala.quoted.runtime.Expr.splice[ConstTests.this.NotSimpleAlg[cats.tagless.Const[scala.Int].<none>]](((evidence$1: scala.quoted.Quotes) ?=> cats.tagless.macros.MacroConst.inline$deriveConst[[F >: scala.Nothing <: [_$1 >: scala.Nothing <: scala.Any] => scala.Any] => ConstTests.this.NotSimpleAlg[F], scala.Int](scala.quoted.runtime.Expr.quote[scala.Int](42).apply(using evidence$1))(scala.quoted.Type.of[[F >: scala.Nothing <: [_$1 >: scala.Nothing <: scala.Any] => scala.Any] => ConstTests.this.NotSimpleAlg[F]](evidence$1), scala.quoted.Type.of[scala.Int](evidence$1), evidence$1)))
[error]    |               |
[error]    |               |The macro returned:
[error]    |               |{
[error]    |  class $anon$macro$1 extends java.lang.Object with ConstTests.this.NotSimpleAlg[[T >: scala.Nothing <: scala.Any] => scala.Int] {
[error]    |    override def str(str: scala.Predef.String): scala.Predef.String = 42
[error]    |    override def parseInt(`str₂`: scala.Predef.String): scala.Int = 42
[error]    |    override def divide(dividend: scala.Float, divisor: scala.Float): scala.Int = 42
[error]    |  }
[error]    |  new $anon$macro$1()
[error]    |}
[error]    |               |
[error]    |               |Error:
[error]    |               |assertion failed: Found:    (42 : Int)
[error]    |Required: String
[error]    |found: ??
[error]    |expected: type String in object Predef with type String, flags = <touched>, underlying = String,  = String, String, Object with Serializable with Comparable[String] with CharSequence {...}
[error]    |tree = 42
[error]    |               |
[error]    |stacktrace available when compiling with `-Ydebug`
[error]    |               |
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
```

This is an attempt to align it a bit with the Scala 2 Macro in terms of error handling:

```scala
[error] 44 |    Derive.const[NotSimpleAlg, Int](42)
[error]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |   Expected method str to return scala.Int but found scala.Predef.String
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from ConstTests.scala:44
[error] 45 |  inline def const[Alg[_[_]], A](value: A): Alg[Const[A]#λ] = MacroConst.derive[Alg, A](value)
[error]    |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     ----------------------------------------------------------------------------
[error] one error found
```