### PR TITLE
fix(scala3): annotation on FunctorK macro splice

### DIFF
--- a/core/src/main/scala-3/cats/tagless/macros/MacroFunctorK.scala
+++ b/core/src/main/scala-3/cats/tagless/macros/MacroFunctorK.scala
@@ -24,7 +24,7 @@ import scala.quoted.*
 
 @experimental
 object MacroFunctorK:
-  inline def derive[Alg[_[_]]]: FunctorK[Alg] = ${ functorK }
+  inline def derive[Alg[_[_]]]: FunctorK[Alg] = ${ functorK[Alg] }
 
   def functorK[Alg[_[_]]: Type](using Quotes): Expr[FunctorK[Alg]] = '{
     new FunctorK[Alg]:


### PR DESCRIPTION
Reproducer:

`repro.sc`:

```scala
//> using scala "3.3.4"
//> using dep org.typelevel::cats-tagless-core::0.16.2

import cats.tagless.FunctorK
import scala.annotation.experimental

trait Foo[F[_]] {
  def bar: F[Unit]
}

@experimental
object Foo {
  implicit val functorK: FunctorK[Foo] = cats.tagless.Derive.functorK[Foo]
}
```

Before:
```sh
$ scala-cli repro.sc
Compiling project (Scala 3.3.4, JVM (21))
[error] ./repro.sc:13:42
[error] no implicit values were found that match type cats.tagless.FunctorK[[G[_$6]] =>> G[Unit]]
[error]   implicit val functorK: FunctorK[Foo] = cats.tagless.Derive.functorK[Foo]
[error]                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error compiling project (Scala 3.3.4, JVM (21))
Compilation failed
```

After (using a locally published snapshot):
```sh
$ scala-cli clean repro.sc
$ scala-cli repro.sc
Compiling project (Scala 3.3.4, JVM (21))
Compiled project (Scala 3.3.4, JVM (21))
```

Background:

In the work codebase, we aim to support 2.12-3LTS whenever feasible. Usually, this means writing as much as possible in the 2.13 dialect and cross-building up to 3.3 and down to 2.12. To this end, we `export cats.tagless.Derive.*` under 3.3 and copy-paste for 2.x to expose a single import that we can use across versions, and we write _lots_ of `implicit val`s instead of `deriving` 😢. We recently moved to the latest version of `cats-tagless-core` from an internal fork since the Scala 3 support has improved significantly, but in trying to upgrade some dependent libraries I started getting errors like the above when cross-building for Scala 3.

Adding the annotation appears to make all things happy, though I don't feel I understand _why_ as much as I might like.

EDIT:

It _can_ be made to compile without this change, but only in the Scala 3 dialect. `inline def` compiles without complaint, though I can't write that in our case without versioned sources (or, _I can_, but I _really_ don't want to 😆).

```diff
-  implicit val functorK: FunctorK[Foo] = cats.tagless.Derive.functorK[Foo]
+  inline implicit def functorK: FunctorK[Foo] = cats.tagless.Derive.functorK[Foo]
```
