### PR TITLE
Add documentation for each macro annotation (issue #7)

### DIFF
--- a/docs/docs/macros/autoApply.md
+++ b/docs/docs/macros/autoApply.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: @autoApply
+section: macros
+position: 5
+---
+
+
+## @autoApply
+
+### Intent
+Generates an instance of `cats.Apply` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods return the type value of the parameter 
+- That are generic method, curried method and varargs parameters
+- With extra type parameter.
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ApplyAlg[T] {
+    def abstractEffect(a: String): T
+    def curried(a: String)(b: Int): T
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoApply
+trait ApplyAlg[T] {
+  def abstractEffect(a: String): T
+    def curried(a: String)(b: Int): T
+}
+```
+
+This expands to
+```scala
+object ApplyAlg {
+  implicit def applyForApplyAlg: Apply[ApplyAlg] =
+      Derive.apply[ApplyAlg]
+}
+```
+#### Extra type parameter
+```scala
+import cats.tagless._
+
+@autoApply
+trait ApplyAlgWithExtraTypeParam[T1, T] {
+  def foo(a: T1): T
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Apply` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- Methods that that do not involve type parameter are ignored.
+
+
+## Test Behavior(Verified)
+The generated instance for `ApplyAlg[T]` satisfies all `Apply` laws including:
+- Composition 
+- Identity
+- Consistency between `map2`, `product`, and `map`
+- Associativity
+- Serialization

--- a/docs/docs/macros/autoApplyK.md
+++ b/docs/docs/macros/autoApplyK.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: @autoApplyK
+section: macros
+position: 6
+---
+
+
+## @autoApplyK
+
+### Intent
+Generates an instance of `cats.ApplyK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With single higher‑kinded type parameter (e.g., `F[_]`)
+- Where methods return the type value of the parameter (e.g., `F[Int]`, `EitherT[F, E, A]`)
+- That are generic method, curried method and varargs parameters
+- With extra type parameters.
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ApplyKAlg[F[_]] {
+  def parseInt(str: String): F[Int]
+  def parseDouble(str: String): EitherT[F, String, Double]
+  def divide(dividend: Float, divisor: Float): F[Float]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoApplyK
+trait ApplyKAlg[F[_]] {
+  def parseInt(str: String): F[Int]
+  def parseDouble(str: String): EitherT[F, String, Double]
+  def divide(dividend: Float, divisor: Float): F[Float]
+}
+```
+
+This expands to
+```scala
+object ApplyKAlg {
+  implicit def applyKForApplyKAlg: ApplyK[ApplyKAlg] =
+      Derive.applyK[ApplyKAlg]
+}
+```
+#### VarArgs Parameter
+```scala
+@autoApplyK
+  trait ApplyKAlgWithVarArgsParameter[F[_]] {
+    def sum(xs: Int*): Int
+    def fSum(xs: Int*): F[Int]
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives ApplyK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that return non-effect types (e.g. `String`, `Int`).
+
+
+## Test Behavour
+The generated instance for `ApplyKAlg[F[_]]` satisfies all `ApplyK` laws including:
+- Composition (covariant and invariant)
+- Identity (covariant and invariant)
+- Semigroupal associativity
+- Associativity
+- Serialization

--- a/docs/docs/macros/autoBifunctor.md
+++ b/docs/docs/macros/autoBifunctor.md
@@ -1,0 +1,73 @@
+---
+layout: page
+title: @autoBifunctor
+section: macros
+position: 7
+---
+
+
+## @autoBifunctor
+
+### Intent
+Generates an instance of `cats.Bifunctor` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With two type parameters (e.g., `A, B`) 
+- Where methods return or consume those type parameters
+- That are generic method, curried method and varargs parameters
+- With extra type parameters.
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait BifunctorAlg[A, B] {
+    def left: A
+    def right: B
+    def fromInt(i: Int): A
+    def fromString(s: String): B
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoBifunctor
+trait BifunctorAlg[A, B] {
+    def left: A
+    def right: B
+    def fromInt(i: Int): A
+    def fromString(s: String): B
+}
+```
+
+This expands to
+```scala
+object BifunctorAlg {
+  implicit def bifunctorAlgForAutoApplyKAlg: BifunctorAlg[BifunctorAlg] =
+      Derive.bifunctor[BifunctorAlg]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Bifunctor` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that do not involve the last two type parameters.
+
+
+## Test Behavior
+The generated instance for `BifunctorAlg[A, B]` satisfies all `Bifunctor` laws including:
+- Identity 
+- Associativity 
+- `leftMap` identity
+- `leftMap` associativity
+- Serialization

--- a/docs/docs/macros/autoContravariant.md
+++ b/docs/docs/macros/autoContravariant.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: @autoContravariant
+section: macros
+position: 8
+---
+
+
+## @autoContravariant
+
+### Intent
+Generates an instance of `cats.Contravariant` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods consume values of that type parameter (e.g., `def foo(t: T): String`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the contravariant one
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ContravariantAlg[T] {
+    def foo(t: T): String
+    def bar(opt: Option[T]): String
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoContravariant
+trait ContravariantAlg[T] {
+    def foo(t: T): String
+    def bar(opt: Option[T]): String
+  
+}
+```
+
+This expands to
+```scala
+object ContravariantAlg {
+  implicit def contravariantForContravariantAlg: Contravariant[ContravariantAlg] =
+      Derive.contravariant[ContravariantAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoContravariant
+  trait ContravariantAlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1, b: T): Int
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Contravariant` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that do not involve the contravariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `ContravariantAlg[T]` satisfies all `Contravariant` laws including:
+- Contravariant composition
+- Contravariant identity  
+- Invariant composition
+- Invariant identity
+- Serialization

--- a/docs/docs/macros/autoContravariantK.md
+++ b/docs/docs/macros/autoContravariantK.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: @autoContravariantK
+section: macros
+position: 9
+---
+
+
+## @autoContravariantK
+
+### Intent
+Generates an instance of `cats.ContravariantK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single higher-kinded type parameter (e.g., `[F[_]]`)
+- Where methods consume values of that type parameter (e.g., `F[Int]`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the contravariant one
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ContravariantKAlg[F[_]] {
+    def sum(xs: F[Int]): Int
+    def sumAll(xss: F[Int]*): Int
+    def foldSpecialized(init: String)(f: (Int, String) => Int): Cokleisli[F, String, Int]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoContravariantK
+trait ContravariantKAlg[F[_]] {
+    def sum(xs: F[Int]): Int
+    def sumAll(xss: F[Int]*): Int
+    def foldSpecialized(init: String)(f: (Int, String) => Int): Cokleisli[F, String, Int]
+  
+}
+```
+
+This expands to
+```scala
+object ContravariantKAlg {
+  implicit def contravariantKForContravarianKAlg: ContravariantK[ContravariantKAlg] =
+      Derive.contravariantK[ContravariantKAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoContravariantK
+  trait ContravariantKAlgWithExtraTypeParam[F[_], A] extends Contravariant[F] {
+    def fold[B](init: B)(f: (B, A) => B): Cokleisli[F, A, B]
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives ContravariantK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that do not involve the contravariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `ContravariantKAlg[F[_]]` satisfies all `ContravariantK` laws including:
+- Contravariant composition
+- Contravariant identity  
+- Invariant composition
+- Invariant identity
+- Serialization

--- a/docs/docs/macros/autoFlatMap.md
+++ b/docs/docs/macros/autoFlatMap.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: @autoFlatMap
+section: macros
+position: 10
+---
+
+
+## @autoFlatMap
+
+### Intent
+Generates an instance of `cats.FlatMap` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods consume values of that type parameter (e.g., `def foo(t: T): String`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the contravariant one
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait FlatMapAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoFlatMap
+trait FlatMapAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+}
+```
+
+This expands to
+```scala
+object FlatMapAlg {
+  implicit def flatMapForFlatMapAlg: FlatMap[FlatMapAlg] =
+      Derive.flatMap[FlatMapAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoFlatMap
+  trait FlatMapAlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1, b: T): Int
+  }
+```
+
+#### Generic and vararg methods
+```scala
+@autoFlatMap
+  trait FlatMapAlgWithGenericMethod[T] {
+    def plusOne[A](i: A): T
+  }
+
+  @autoFlatMap
+  trait FlatMapAlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def generic[A](as: A*): T
+  }
+```
+
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives FlatMap` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that do not involve the contravariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `FlatMapAlg[T]` satisfies all `FlatMap` laws including:
+
+- `apply` composition
+- FlatMap associativity
+- Consistency with `apply`, `tailRecM`, and `map`
+- `mproduct`, `productL`, `productR` consistency
+- `map2`, `map2Eval`, and `product` consistency
+- Semigroupal associativity
+- Convariant identity and composition 
+- Invariant composition and identity
+- Serialization

--- a/docs/docs/macros/autoFunctor.md
+++ b/docs/docs/macros/autoFunctor.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: @autoFunctor
+section: macros
+position: 11
+---
+
+
+## @autoFunctor
+
+### Intent
+Generates an instance of `cats.Functor` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods consume values of that type parameter (e.g., `def foo(t: T): String`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the contravariant one
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait FunctorAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def toList(xs: List[Int]): List[T]
+    def fromFunction(f: T => String): T
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoFunctor
+trait FunctorAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def toList(xs: List[Int]): List[T]
+    def fromFunction(f: T => String): T
+}
+```
+
+This expands to
+```scala
+object FunctorAlg {
+  implicit def functorForFunctorAlg: Functor[FunctorAlg] =
+      Derive.functor[FunctorAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoFunctor
+  trait FunctorAlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1): T
+  }
+```
+
+#### Generic and vararg methods
+```scala
+@autoFunctor
+  trait FunctorAlgWithGenericMethod[T] {
+    def plusOne[A](i: A): T
+  }
+
+  @autoFunctor
+  trait FunctorAlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def generic[A](as: A*): T
+  }
+```
+
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Functor` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+- It ignores methods that do not involve the contravariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `FunctorAlg[T]` satisfies all `Functor` laws including:
+
+- `mapOrKeepToMap` equivalence
+- Convariant identity and composition 
+- Invariant composition and identity
+- Serialization

--- a/docs/docs/macros/autoFunctorK.md
+++ b/docs/docs/macros/autoFunctorK.md
@@ -1,0 +1,82 @@
+---
+layout: page
+title: @autoFunctorK
+section: macros
+position: 12
+---
+
+
+## @autoFunctorK
+
+### Intent
+Generates an instance of `cats.FunctorK` in the companion object of the annotated trait.
+
+### Scope
+- With a single higher-kinded type parameter (e.g., `F[_]`)
+- Where methods return values of that type parameter (e.g., `F[Int]`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the effect type
+- That use type members, type bounds, context bounds, or abstract type classes
+- That define default parameters, final methods, or by-name parameters
+- That follow builder-style algebra patterns
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait FunctorKAlg[F[_]] {
+  def parseInt(str: String): F[Int]
+  def divide(dividend: Float, divisor: Float): F[Float]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoFunctorK
+trait FunctorKAlg[F[_]] {
+    def parseInt(str: String): F[Int]
+  def divide(dividend: Float, divisor: Float): F[Float]
+}
+```
+
+This expands to
+```scala
+object FunctorKAlg {
+  implicit def functoKrForFunctorKAlg: Functor[FunctorKAlg] =
+      Derive.functor[FunctorKAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoFunctorK
+  trait FunctorKAlgWithExtraParam[F[_], A] {
+  def a(i: Int): F[A]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives FunctorK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Abstract type classes
+  - Default parameters
+  - Final methods
+  - By-nameparameters
+- It ignores methods that do not involve the contravariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `FunctorKAlg[F[_]]` satisfies all `FunctorK` laws including:
+- Convariant identity and composition 
+- Invariant composition and identity
+- Serialization

--- a/docs/docs/macros/autoInstrument.md
+++ b/docs/docs/macros/autoInstrument.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: @autoInstrument
+section: macros
+position: 13
+---
+
+
+## @autoInstrument
+
+### Intent
+Generates an instance of `cats.Instrument` in the companion object of the annotated trait.
+
+### Scope
+- With a single higher-kinded type parameter (e.g., `F[_]`)
+- Where methods return values wrapped in that effect type
+- That may contain non-effect methods.
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait InstrumentAlg[F[_]] {
+   def ->(id: String): F[Option[Long]]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoInstrument
+@finalAlg
+trait InstrumentAlg[F[_]] {
+    def ->(id: String): F[Option[Long]]
+  }
+```
+
+This expands to
+```scala
+object InstrumentAlg {
+  implicit def instrumentForInstrumentAlg: Instrument[InstrumentAlg] =
+      Derive.instrument[InstrumentAlg]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Instrument` syntax instead.
+- Requires `@finalAlg` for proper derivation in most cases.
+- It can handle: 
+  - Non effect methods
+  - Default implementations
+- It ignores methods that do not involve the effect type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `InstrumentAlg[F[_]]` satisfies all `Instrument` laws including:
+- Convariant identity and composition 
+- Invariant composition and identity
+- Preserving semantics of instrumented methods
+- Serialization

--- a/docs/docs/macros/autoInvariant.md
+++ b/docs/docs/macros/autoInvariant.md
@@ -1,0 +1,105 @@
+---
+layout: page
+title: @autoInvariant
+section: macros
+position: 14
+---
+
+
+## @autoInvariant
+
+### Intent
+Generates an instance of `cats.Invariant` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods consume or return values of that type parameter (e.g., `def foo(t: T): String`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the invariant one
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait InvariantAlg[T] {
+    def foo(a: T): T
+    def headOption(ts: List[T]): Option[T]
+    def map[U](ts: List[T])(f: T => U): List[U] = ts.map(f)
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoInvariant
+trait InvariantAlg[T] {
+    def foo(a: T): T
+    def headOption(ts: List[T]): Option[T]
+    def map[U](ts: List[T])(f: T => U): List[U] = ts.map(f)
+}
+```
+
+This expands to
+```scala
+object InvariantAlg {
+  implicit def invariantForInvariantAlg: Invariant[InvariantAlg] =
+      Derive.invariant[InvariantAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoInvariant
+  trait InvariantAlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1, b: T): T
+  }
+```
+
+#### Generic and vararg methods
+```scala
+@autoInvariant
+  trait InvariantAlgWithGenericMethod[T] {
+    def foo[A](i: T, a: A): T
+  }
+
+  @autoInvariant
+  trait InvariantAlgWithVarArgsParameter[T] {
+    def sum(xs: Int*): Int
+    def covariantSum(xs: Int*): T
+    def contravariantSum(xs: T*): Int
+    def invariantSum(xs: T*): T
+  }
+```
+#### Non-effect methods
+
+```scala
+@autoInvariant
+  trait InvariantAlgWithGenericMethod[T] {
+    def foo(a: String): Float = a.length.toFloat
+    def foo2(a: String): String = a.reverse
+    def foo3(a: Float): String = a.toInt.toString
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Invariant` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Extra type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Defaualt implementations
+- It ignores methods that do not involve the invariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `InvariantAlg[T]` satisfies all `Invariant` laws including:
+- Invariant composition and identity
+- Serialization

--- a/docs/docs/macros/autoInvariantK.md
+++ b/docs/docs/macros/autoInvariantK.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: @autoInvariantK
+section: macros
+position: 15
+---
+
+
+## @autoInvariantK
+
+### Intent
+Generates an instance of `cats.InvariantK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single higher-kinded type parameter (e.g., `[F[_]]`)
+- Where methods consume or return values of that type parameter (e.g., `F[Int]`)
+- That are generic methods, curried methods and varargs 
+- That may contain non-effect methods.
+- That define extra type parameters beyond the effect one
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait InvariantKAlg[F[_]] {
+  def parseInt(str: String): F[Int]
+  def divide(dividend: Float, divisor: Float): F[Float]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoInvariantK
+trait InvariantKAlg[F[_]] {
+    def parseInt(str: String): F[Int]
+    def divide(dividend: Float, divisor: Float): F[Float]
+  
+}
+```
+
+This expands to
+```scala
+object InvariantKAlg {
+  implicit def invariantKForInvarianKAlg: InvariantK[InvariantKAlg] =
+      Derive.invariantK[InvariantKAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoInvariantK
+  @autoInvariantK @finalAlg
+  trait InvariantKWithExtraTpeParam[F[_], T] {
+    def a(i: F[T]): F[T]
+    def b(i: F[Int]): F[T]
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives InvariantK` syntax instead.
+- May require `@finalAlg`.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Default implementations
+- It ignores methods that do not involve the invariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `InvariantKAlg[F[_]]` satisfies all `InvariantK` laws including:  
+- Invariant composition
+- Invariant identity
+- Serialization

--- a/docs/docs/macros/autoMonoidK.md
+++ b/docs/docs/macros/autoMonoidK.md
@@ -1,0 +1,74 @@
+---
+layout: page
+title: @autoMonoidK
+section: macros
+position: 16
+---
+
+
+## @autoMonoidK
+
+### Intent
+Generates an instance of `cats.MonoidK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods return values of that type parameter wrapped in a collection-like structure (e.g., `Map[String, T]`)
+- That may contain non-effect methods.
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait MonoidKAlg[T] {
+    def abstractEffect(a: String): Map[String, T]
+    def concreteEffect(a: String): Map[String, T] = abstractEffect(a + " concreteEffect")
+    def abstractOther(t: T): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: Int
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoMonoidK
+trait MonoidKAlg[T] {
+    def abstractEffect(a: String): Map[String, T]
+    def concreteEffect(a: String): Map[String, T] = abstractEffect(a + " concreteEffect")
+    def abstractOther(t: T): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: Int
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+This expands to
+```scala
+object MonoidKAlg {
+  implicit def monoidKForMonoidKAlg: MonoidK[MonoidKAlg] =
+      Derive.monoidK[MonoidKAlg]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives MonoidK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Extra type parameters in the traits
+  - Non-effect methods
+  - Defaualt implementations
+- It ignores methods that do not involve type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `MonoidKAlg[T]` satisfies all `MonoidK` laws including:
+- Left identity
+- Right identity
+- Associativity
+- Serialization

--- a/docs/docs/macros/autoProductNK.md
+++ b/docs/docs/macros/autoProductNK.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: @autoProductNK
+section: macros
+position: 17
+---
+
+
+## @autoProductNK
+
+### Intent
+Generates methods in companion object to compose multiple interpreters into an interpreter of a `TupleNK` effects
+
+### Scope
+The annotation can be applied to traits:
+- With a single higher-kinded type parameter (e.g., `[F[_]]`)
+- Where methods consume or return values of that effect type
+- That are generic methods, curried methods and varargs 
+- That may contain multiple parameter lists
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ProductNKAlgWithGenericType[F[_]] {
+    def a[T](a: T): F[Unit]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoProductNK
+trait ProductNKAlgWithGenericType[F[_]] {
+    def a[T](a: T): F[Unit]
+}
+```
+
+This expands to
+```scala
+object ProductNKAlgWithGenericType {
+  def product3K[F1[_], F2[_], F3[_]](
+    af1: algWithGenericType[F1],
+    af2: algWithGenericType[F2],
+    af3: algWithGenericType[F3]
+  ): algWithGenericType[Tuple3K[F1, F2, F3]#λ] =
+    new algWithGenericType[Tuple3K[F1, F2, F3]#λ] {
+      def a[T](t: T): Tuple3K[F1, F2, F3]#λ[Unit] =
+        (af1.a(t), af2.a(t), af3.a(t))
+    }
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives ProductNK` syntax instead.
+- Does not generate a type class instance, but instead companion methods.
+- It can handle: 
+  - Type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Multiple parameter lists

--- a/docs/docs/macros/autoProfunctor.md
+++ b/docs/docs/macros/autoProfunctor.md
@@ -1,0 +1,94 @@
+---
+layout: page
+title: @autoProfunctor
+section: macros
+position: 18
+---
+
+
+## @autoProfunctor
+
+### Intent
+Generates an instance of `cats.Profunctor` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With two type parameters (e.g., `A, B`)
+- Where methods consume values of the first type parameter (`A`) and/or return values of the second type parameter (`B`)
+- That are include generic methods, curried methods and varargs 
+- That define extra type parameters beyond the two Profunctor ones
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait ProfunctorAlg[A, B] {
+    def abstractCovariant(str: String): B
+    def concreteCovariant(str: String): B = abstractCovariant(str + " concreteCovariant")
+    def abstractContravariant(a: A): String
+    def concreteContravariant(a: A): String = abstractContravariant(a) + " concreteContravariant"
+    def abstractMixed(a: A): B
+    def concreteMixed(a: A): B = abstractMixed(a)
+    def abstractOther(str: String): String
+    def concreteOther(str: String): String = str + " concreteOther"
+    def withoutParams: B
+    def fromList(as: List[A]): List[B]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoProfunctor
+trait ProfunctorAlg[A, B] {
+    def abstractCovariant(str: String): B
+    def concreteCovariant(str: String): B = abstractCovariant(str + " concreteCovariant")
+    def abstractContravariant(a: A): String
+    def concreteContravariant(a: A): String = abstractContravariant(a) + " concreteContravariant"
+    def abstractMixed(a: A): B
+    def concreteMixed(a: A): B = abstractMixed(a)
+    def abstractOther(str: String): String
+    def concreteOther(str: String): String = str + " concreteOther"
+    def withoutParams: B
+    def fromList(as: List[A]): List[B]
+}
+```
+
+This expands to
+```scala
+object ProfunctorAlg {
+  implicit def profunctorForProfunctorAlg: Profunctor[ProfunctorAlg] =
+      Derive.profunctor[ProfunctorAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoProfunctor
+  trait ProfunctorAlgWithExtraTypeParam[T, A, B] {
+   def foo(t: T, a: A): B
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Profunctor` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Extra type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Defaualt implementations
+- It ignores methods that do not involve the Profunctor type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `ProfunctorAlg[A, B]` satisfies all `Profunctor` laws including:
+- Profunctor composition and identity
+- `lmap` composition and identity
+- `rmap` composition and identity
+- Serialization

--- a/docs/docs/macros/autoSemigroupK.md
+++ b/docs/docs/macros/autoSemigroupK.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: @autoSemigroupK
+section: macros
+position: 21
+---
+
+
+## @autoSemigroupK
+
+### Intent
+Generates an instance of `cats.SemigroupK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods return values of that type parameter wrapped in a `SemigroupK`-compatible effect (e.g., `Validated[Int, T]`)
+- That may contain non-effect methods.
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait SemigroupKAlg[T] {
+    def abstractEffect(a: String): Validated[Int, T]
+    def concreteEffect(a: String): Validated[Int, T] = abstractEffect(a + " concreteEffect")
+    def abstractOther(t: T): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: Comparison
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoSemigroupK
+trait SemigroupKAlg[T] {
+    def abstractEffect(a: String): Validated[Int, T]
+    def concreteEffect(a: String): Validated[Int, T] = abstractEffect(a + " concreteEffect")
+    def abstractOther(t: T): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: Comparison
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+This expands to
+```scala
+object SemigroupKAlg {
+  implicit def semigroupKForSemigroupKAlg: SemigroupK[SemigroupKAlg] =
+      Derive.semigroupK[SemigroupKAlg]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives SemigroupK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Extra type parameters in the traits
+  - Non-effect methods
+  - Defaualt implementations
+- It ignores methods that do not involve the SemigroupK type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `SemigroupKAlg[T]` satisfies all `SemigroupK` laws including:
+- Associability
+- Serialization

--- a/docs/docs/macros/autoSemigroupal.md
+++ b/docs/docs/macros/autoSemigroupal.md
@@ -1,0 +1,101 @@
+---
+layout: page
+title: @autoSemigroupal
+section: macros
+position: 19
+---
+
+
+## @autoSemigroupal
+
+### Intent
+Generates an instance of `cats.Semigroupal` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single type parameter (e.g., `T`)
+- Where methods consume or return values of that type parameter (e.g., `def foo(t: T): String`)
+- That are generic methods, curried methods and varargs 
+- That may contain constant return types 
+- That may provide default method implementations
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait SemigroupalAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def curried(a: String)(b: Int): T
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoSemigroupal
+trait SemigroupalAlg[T] {
+    def abstractEffect(a: String): T
+    def concreteEffect(a: String): T = abstractEffect(a + " concreteEffect")
+    def abstractOther(a: String): String
+    def concreteOther(a: String): String = a + " concreteOther"
+    def withoutParams: T
+    def curried(a: String)(b: Int): T
+    def headOption(ts: List[T]): Option[T]
+}
+```
+
+This expands to
+```scala
+object SemigroupalAlg {
+  implicit def semigroupalForSemigroupalAlg: Semigroupal[SemigroupalAlg] =
+      Derive.semigroupal[SemigroupalAlg]
+}
+```
+
+#### Extra type Parameters
+
+```scala
+@autoSemigroupal
+  trait SemigroupalAlgWithExtraTypeParam[T1, T] {
+    def foo(a: T1): T
+  }
+```
+
+#### Generic and vararg methods
+```scala
+@autoSemigroupal
+  trait SemigroupalAlgWithGenericMethod[T] {
+   def plusOne[A](i: A): T
+  }
+
+  @autoSemigroupal
+  trait SemigroupalAlgWithVarArgsParameter[T] {
+      def sum(xs: Int*): Int
+      def product(xs: Int*): T
+  }
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives Semigroupal` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Extra type parameters in the traits
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Constant return types
+  - Defaualt implementations
+- It ignores methods that do not involve the invariant type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `SemigroupalAlg[T]` satisfies all `Semigroupal` laws including:
+- Associativity
+- Serialization

--- a/docs/docs/macros/autoSemigroupalK.md
+++ b/docs/docs/macros/autoSemigroupalK.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: @autoSemigroupalK
+section: macros
+position: 20
+---
+
+
+## @autoSemigroupalK
+
+### Intent
+Generates an instance of `cats.SemigroupalK` in the companion object of the annotated trait.
+
+### Scope
+The annotation can be applied to traits:
+- With a single higher-kinded type parameter (e.g., `F[_]`)
+- Where methods return values of that effect type
+- That may contain constant return types 
+- That are generic methods, curried methods and varargs 
+
+### Examples
+#### Before Annotation
+```scala
+import cats.tagless._
+
+trait SemigroupalKAlgF[F[_]] {
+    def sum(xs: Int*): Int
+    def effectfulSum(xs: Int*): F[Int]
+}
+```
+
+#### After applying the macro 
+```scala
+import cats.tagless._
+
+@autoSemigroupalK
+trait SemigroupalKAlg[F[_]] {
+    def sum(xs: Int*): Int
+    def effectfulSum(xs: Int*): F[Int]
+}
+```
+
+This expands to
+```scala
+object SemigroupalKAlg {
+  implicit def semigroupalKForSemigroupalKAlg: SemigroupalK[SemigroupalKAlg] =
+      Derive.semigroupalK[SemigroupalKAlg]
+}
+```
+
+### Dependency and Limitation
+- Works only on Scala 2; not supported in Scala 3.
+In Scala 3 use native `derives SemigroupalK` syntax instead.
+- The annotation does not need to be combined with other annotations.
+- It can handle: 
+  - Generic methods
+  - Varargs
+  - Curried method
+  - Constant return types
+- It ignores methods that do not involve the effect type parameter.
+
+## Test Behavior (Verified)
+The generated instance for `SemigroupalKAlg[T]` satisfies all `SemigroupalK` laws including:
+- Associativity
+- Serialization


### PR DESCRIPTION
Updated the doc with the documentation of each macro annotation covering the following:

1. Intent of the annotation
2. Scope of the annotation
3. Code snippet showing annotated traits before and after applying macro
4. Dependencies and Limitations
5. Test Behavior
